### PR TITLE
Fix Python 2 compatibility ('clear()' method on list)

### DIFF
--- a/textx/model.py
+++ b/textx/model.py
@@ -473,7 +473,7 @@ def parse_tree_to_objgraph(parser, parse_tree):
                 attr_value.append(resolved)
             else:
                 setattr(obj, attr.name, resolved)
-        parser._crossrefs.clear()
+        del parser._crossrefs[:]
 
     def call_obj_processors(model_obj):
         """


### PR DESCRIPTION
The previous code was using the 'clear()' method upon the '_crossrefs'
collection. This method had been introduced in Python 3.3 and thus
breaks the Python 2 compatibility. So, the call:

    parser._crossrefs.clear()

is changed to:

    del parser._crossrefs[:]