### PR TITLE
FLOAT terminal now matches floats ending with "."

### DIFF
--- a/tests/functional/test_textx_language.py
+++ b/tests/functional/test_textx_language.py
@@ -376,11 +376,12 @@ def test_float_variations():
     """
     meta = metamodel_from_str(grammar)
 
-    model = meta.model_from_str('3.5, .4, 5.0')
-    assert len(model.a) == 3
+    model = meta.model_from_str('3.5, .4, 5.0, 6.')
+    assert len(model.a) == 4
     assert type(model.a[0]) is float
     assert type(model.a[1]) is float
     assert type(model.a[2]) is float
+    assert type(model.a[3]) is float
 
     # Check scientific notation
     model = meta.model_from_str('1e-2')

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -89,7 +89,7 @@ def comment_block():        return _(r'/\*(.|\n)*?\*/')
 ID          = _(r'[^\d\W]\w*\b', rule_name='ID', root=True)
 BOOL        = _(r'(True|true|False|false|0|1)\b', rule_name='BOOL', root=True)
 INT         = _(r'[-+]?[0-9]+\b', rule_name='INT', root=True)
-FLOAT       = _(r'[+-]?(\d+(\.\d*)?|\.\b\d+)([eE][+-]?\d+)?(?<=[\w\.])(?![\w\.])',
+FLOAT       = _(r'[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?(?<=[\w\.])(?![\w\.])',
                 'FLOAT', root=True)
 STRING      = _(r'("(\\"|[^"])*")|(\'(\\\'|[^\'])*\')', 'STRING', root=True)
 NUMBER      = OrderedChoice(nodes=[FLOAT, INT], rule_name='NUMBER', root=True)

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -89,7 +89,7 @@ def comment_block():        return _(r'/\*(.|\n)*?\*/')
 ID          = _(r'[^\d\W]\w*\b', rule_name='ID', root=True)
 BOOL        = _(r'(True|true|False|false|0|1)\b', rule_name='BOOL', root=True)
 INT         = _(r'[-+]?[0-9]+\b', rule_name='INT', root=True)
-FLOAT       = _(r'[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\b', 'FLOAT',
+FLOAT       = _(r'[-+]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?', 'FLOAT',
                 root=True)
 STRING      = _(r'("(\\"|[^"])*")|(\'(\\\'|[^\'])*\')', 'STRING', root=True)
 NUMBER      = OrderedChoice(nodes=[FLOAT, INT], rule_name='NUMBER', root=True)

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -89,8 +89,8 @@ def comment_block():        return _(r'/\*(.|\n)*?\*/')
 ID          = _(r'[^\d\W]\w*\b', rule_name='ID', root=True)
 BOOL        = _(r'(True|true|False|false|0|1)\b', rule_name='BOOL', root=True)
 INT         = _(r'[-+]?[0-9]+\b', rule_name='INT', root=True)
-FLOAT       = _(r'[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?', 'FLOAT',
-                root=True)
+FLOAT       = _(r'[+-]?(\d+(\.\d*)?|\.\b\d+)([eE][+-]?\d+)?(?<=[\w\.])(?![\w\.])',
+                'FLOAT', root=True)
 STRING      = _(r'("(\\"|[^"])*")|(\'(\\\'|[^\'])*\')', 'STRING', root=True)
 NUMBER      = OrderedChoice(nodes=[FLOAT, INT], rule_name='NUMBER', root=True)
 BASETYPE    = OrderedChoice(nodes=[NUMBER, BOOL, ID, STRING],

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -89,7 +89,7 @@ def comment_block():        return _(r'/\*(.|\n)*?\*/')
 ID          = _(r'[^\d\W]\w*\b', rule_name='ID', root=True)
 BOOL        = _(r'(True|true|False|false|0|1)\b', rule_name='BOOL', root=True)
 INT         = _(r'[-+]?[0-9]+\b', rule_name='INT', root=True)
-FLOAT       = _(r'[-+]?([0-9]*[.])?[0-9]*([eE][-+]?[0-9]+)?', 'FLOAT',
+FLOAT       = _(r'[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?', 'FLOAT',
                 root=True)
 STRING      = _(r'("(\\"|[^"])*")|(\'(\\\'|[^\'])*\')', 'STRING', root=True)
 NUMBER      = OrderedChoice(nodes=[FLOAT, INT], rule_name='NUMBER', root=True)

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -89,7 +89,7 @@ def comment_block():        return _(r'/\*(.|\n)*?\*/')
 ID          = _(r'[^\d\W]\w*\b', rule_name='ID', root=True)
 BOOL        = _(r'(True|true|False|false|0|1)\b', rule_name='BOOL', root=True)
 INT         = _(r'[-+]?[0-9]+\b', rule_name='INT', root=True)
-FLOAT       = _(r'[-+]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?', 'FLOAT',
+FLOAT       = _(r'[-+]?([0-9]*[.])?[0-9]*([eE][-+]?[0-9]+)?', 'FLOAT',
                 root=True)
 STRING      = _(r'("(\\"|[^"])*")|(\'(\\\'|[^\'])*\')', 'STRING', root=True)
 NUMBER      = OrderedChoice(nodes=[FLOAT, INT], rule_name='NUMBER', root=True)


### PR DESCRIPTION
Small adaptation to FLOAT regex to be able to cope with cases such as `1.e-2` . Closes #37.