### PR TITLE
Master issue78

### DIFF
--- a/tests/functional/regressions/test_issue78.py
+++ b/tests/functional/regressions/test_issue78.py
@@ -1,0 +1,21 @@
+import textx
+def test_issue78_obj_processors_base_attr_proc():
+    mm = textx.metamodel_from_str('''
+        Model: base+=Base;
+        Special1: '1' name=ID;
+        Special2: '2' name=ID test=TestObj;
+        Base: Special1|Special2;
+        TestObj: name=ID;
+    ''')
+    test_list=[]
+    mm.register_obj_processors({
+        'TestObj': lambda o: test_list.append(o.name),
+    })
+    m = mm.model_from_str('''
+    1 S1a
+    1 S1b
+    2 S2a t2a
+    2 S2b t2b
+    ''')
+    assert ['t2a','t2b'] == test_list
+

--- a/tests/functional/regressions/test_issue78.py
+++ b/tests/functional/regressions/test_issue78.py
@@ -147,10 +147,9 @@ def test_issue78_quickcheck_no_obj_processors_called_for_references():
     assert ['a1','a2','a3'] == test_list
 
     # only references to A: --> obj proc not called
-    test_list=[]
     global_repo_provider.add_model(m1)
     m2 = mm.model_from_str('''
     B b1 -> a1 B b2 -> a2 B b3 -> a3
     ''')
-    assert [] == test_list
+    assert ['a1','a2','a3'] == test_list # unchanged...
 

--- a/tests/functional/regressions/test_issue78.py
+++ b/tests/functional/regressions/test_issue78.py
@@ -23,3 +23,134 @@ def test_issue78_obj_processors_base_attr_proc():
     ''')
     assert ['t2a','t2b'] == test_list
 
+
+def test_issue78_obj_processors_order_of_eval():
+    """
+    Test shows that different processors can be assigned to Base and
+    Specialized classes (in case of ABSTRACT_RULE)
+    """
+    mm = textx.metamodel_from_str('''
+        Model: base+=Base;
+        Special1: '1' name=ID;
+        Special2: '2' name=ID;
+        Base: Special1|Special2;
+    ''')
+    test_list=[]
+    mm.register_obj_processors({
+        'Base': lambda o: test_list.append('Base_'+o.name),
+        'Special1': lambda o: test_list.append('Special_'+o.name),
+    })
+    m = mm.model_from_str('''
+    1 S1
+    2 S2
+    ''')
+    assert ['Special_S1','Base_S1','Base_S2'] == test_list
+
+
+def test_issue78_obj_processors_replacement1_base():
+    """
+    Test shows that different processors can be assigned to Base and
+    Specialized classes (in case of ABSTRACT_RULE)
+    """
+    mm = textx.metamodel_from_str('''
+        Model: base+=Base;
+        Special1: '1' name=ID;
+        Special2: '2' name=ID;
+        Base: Special1|Special2;
+    ''')
+    test_list=[]
+    mm.register_obj_processors({
+        'Base': lambda o: 'Base_'+o.name,
+        'Special1': lambda o: test_list.append('Special_'+o.name),
+    })
+    m = mm.model_from_str('''
+    1 S1
+    2 S2
+    ''')
+    assert ['Special_S1'] == test_list
+    assert ['Base_S1','Base_S2'] == m.base
+
+
+def test_issue78_obj_processors_replacement2_specialized():
+    """
+    Test shows that different processors can be assigned to Base and
+    Specialized classes (in case of ABSTRACT_RULE)
+    """
+    mm = textx.metamodel_from_str('''
+        Model: base+=Base;
+        Special1: '1' name=ID;
+        Special2: '2' name=ID;
+        Base: Special1|Special2;
+    ''')
+    test_list=[]
+    mm.register_obj_processors({
+        'Base': lambda o: test_list.append('Base_'+o.name),
+        'Special1': lambda o: 'Special_'+o.name,
+    })
+    m = mm.model_from_str('''
+    1 S1
+    2 S2
+    ''')
+    assert ['Base_S1','Base_S2'] == test_list
+    assert 'Special_S1' == m.base[0]
+    assert 'Special1' != m.base[1].__class__.__name__  # it is a str now...
+    assert 'Special2' == m.base[1].__class__.__name__  # this one is unchanged
+
+
+def test_issue78_obj_processors_replacement_domination_of_specialized():
+    """
+    Test shows that different processors can be assigned to Base and
+    Specialized classes (in case of ABSTRACT_RULE)
+    """
+    mm = textx.metamodel_from_str('''
+        Model: base+=Base;
+        Special1: '1' name=ID;
+        Special2: '2' name=ID;
+        Base: Special1|Special2;
+    ''')
+    mm.register_obj_processors({
+        'Base': lambda o: 'Base_'+o.name,
+        'Special1': lambda o: 'Special_'+o.name,
+    })
+    m = mm.model_from_str('''
+    1 S1
+    2 S2
+    ''')
+    assert ['Special_S1','Base_S2'] == m.base
+
+
+def test_issue78_quickcheck_no_obj_processors_called_for_references():
+    """
+    This test represents just a plausibility check.
+    """
+    grammarA = """
+    Model: a+=A | b+=B;
+    A:'A' name=ID;
+    B:'B' name=ID '->' a=[A];
+    """
+
+    mm = textx.metamodel_from_str(grammarA)
+
+    import textx.scoping.providers as scoping_providers
+    global_repo_provider = scoping_providers.PlainNameGlobalRepo()
+    mm.register_scope_providers({"*.*": global_repo_provider})
+
+    test_list=[]
+    mm.register_obj_processors({
+        'A': lambda o: test_list.append(o.name),
+    })
+
+    # no references to A: --> obj proc called
+    m1 = mm.model_from_str('''
+    A a1 A a2 A a3
+    ''')
+    assert ['a1','a2','a3'] == test_list
+
+    # only references to A: --> obj proc not called
+    test_list=[]
+    global_repo_provider.add_model(m1)
+    m2 = mm.model_from_str('''
+    B b1 -> a1 B b2 -> a2 B b3 -> a3
+    ''')
+    assert [] == test_list
+

--- a/tests/functional/regressions/test_issue78.py
+++ b/tests/functional/regressions/test_issue78.py
@@ -93,7 +93,7 @@ def test_issue78_obj_processors_replacement2_specialized():
     ''')
     assert ['Base_S1','Base_S2'] == test_list
     assert 'Special_S1' == m.base[0]
-    assert 'Special1' != m.base[1].__class__.__name__  # it is a str now...
+    assert 'Special1' != m.base[0].__class__.__name__  # it is a str now...
     assert 'Special2' == m.base[1].__class__.__name__  # this one is unchanged
 
 

--- a/tests/functional/regressions/test_issue78.py
+++ b/tests/functional/regressions/test_issue78.py
@@ -1,5 +1,9 @@
 import textx
 def test_issue78_obj_processors_base_attr_proc():
+    """
+    Test works in 1.6.1 (rev 84bfd8748554237dd2a0919c45e761523a4e2712)
+    Test fails in e1981fb74397dc53580e19919bdec95a5e55c7ee (1.7++)
+    """
     mm = textx.metamodel_from_str('''
         Model: base+=Base;
         Special1: '1' name=ID;

--- a/textx/model.py
+++ b/textx/model.py
@@ -518,13 +518,15 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
 
         return inst
 
-    def call_obj_processors(metamodel, model_obj, metaclass_of_grammar_rule=None):
+    def call_obj_processors(metamodel, model_obj,
+                            metaclass_of_grammar_rule=None):
         """
         Depth-first model object processing.
         """
         try:
             if metaclass_of_grammar_rule is None:
-                metaclass_of_grammar_rule = metamodel[model_obj.__class__.__name__]
+                metaclass_of_grammar_rule = \
+                    metamodel[model_obj.__class__.__name__]
         except KeyError:
             raise TextXSemanticError(
                 'Unknown meta-class "{}".'
@@ -591,7 +593,7 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
         if return_value_current is not None:
             return return_value_current
         else:
-            return return_value_grammar # may be None
+            return return_value_grammar  # may be None
 
     model = process_node(parse_tree)
     # Register filename of the model for later use (e.g. imports/scoping).

--- a/textx/model.py
+++ b/textx/model.py
@@ -543,7 +543,7 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
 
             for metaattr in current_metaclass_of_obj._tx_attrs.values():
                 # If attribute is base type or containment reference go down
-                if metaattr.is_base_type or (metaattr.ref and metaattr.cont):
+                if metaattr.cont:
                     attr = getattr(model_obj, metaattr.name)
                     if attr:
                         if metaattr.mult in many:

--- a/textx/model.py
+++ b/textx/model.py
@@ -576,7 +576,7 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
 
         # both obj_processors are called, if two different processors
         # are defined for the object metaclass and the grammar metaclass
-        # (happens with type==RULE_ABSTRACT):
+        # (can happen with type==RULE_ABSTRACT):
         # e.g.
         #   Base: Special1|Special2;
         #   RuleCurrentlyChecked: att_to_be_checked=[Base]

--- a/textx/model.py
+++ b/textx/model.py
@@ -533,19 +533,20 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
         many = [MULT_ONEORMORE, MULT_ZEROORMORE]
 
 
+        # https://stackoverflow.com/questions/3848091/set-iteration-order-varies-from-run-to-run
         if model_obj.__class__.__name__ in metamodel:
             current_metaclass_of_obj = metamodel[model_obj.__class__.__name__]
-            merged_attributes = set(
-                list(metaclass_of_grammar_rule._tx_attrs.values())
-                + list(current_metaclass_of_obj._tx_attrs.values())
-            )
+            attributes_to_process = \
+                list(current_metaclass_of_obj._tx_attrs.values())
+            for attr in metaclass_of_grammar_rule._tx_attrs.values():
+                if attr not in attributes_to_process:
+                    attributes_to_process.append(attr)
         else:
             current_metaclass_of_obj = None
-            merged_attributes = set(
+            attributes_to_process = \
                 list(metaclass_of_grammar_rule._tx_attrs.values())
-            )
 
-        for metaattr in merged_attributes:
+        for metaattr in attributes_to_process:
             # If attribute is base type or containment reference go down
             if metaattr.is_base_type or (metaattr.ref and metaattr.cont):
                 attr = getattr(model_obj, metaattr.name)


### PR DESCRIPTION
This PL represents
 * a possible solution to issue 78 (see first test case in test_issue78.py which worked for textx v1.6.1)
 * a possible extension to be able to (correctly?) handle object processors in case of ABSTRACT_RULEs, when processors are define for the "Base class" and the "Specialized classes".

Before going into the changes, I want to state that I think there should be no performance impact compared to the previous version (when no such multiple object processors are defined): there is no such thing as a new for-loop or similar things. Of course more processors are called now, since (obviously) issue 78 shows that some processors are omitted compared to v1.6.1.

The changes (all in model.py, call_obj_processors)
 * **issue78** (test_issue78_obj_processors_base_attr_proc()): in model.py, call_obj_processors **now uses the metaclass of the model_obj under analysis**, instead of the metaclass derived from the grammar (which could be a "base class" in case ABSTARCT_RULE). This is required, since else attributes from the "specialized class" will not be processed.
 * Extra addition (test_issue78_obj_processors_order_of_eval()): when **multiple object processors can be identified, the processor for the "specialized class" is called first**, followed by the processor of the "base class".
 * Extra addition (test_issue78_obj_processors_replacement*()): when **multiple object processors return a value, the value of the "specialized class"'s processor dominates** (although both processors are called).

All existing projects should have no impacts, when no such processors for "base" and "specialized classes" are defined at the same time...

Note (minor): it is not 100% clear to me, why the MetaAttr-flag "ref" is True for "normal" attributes to be processed by call_obj_processors (this aspect of the code is unchanged). Maybe a glossary defining a "containment", a "reference" and a "containment reference" would help me out...