### PR TITLE
Fixes export failures on nested parses

### DIFF
--- a/textx/lang.py
+++ b/textx/lang.py
@@ -107,7 +107,7 @@ BASE_TYPE_RULES = {rule.rule_name: rule
 BASE_TYPE_NAMES = list(BASE_TYPE_RULES.keys())
 ALL_TYPE_NAMES = BASE_TYPE_NAMES + ['OBJECT']
 
-PRIMITIVE_PYTHON_TYPES = [int, float, text, bool]
+PRIMITIVE_PYTHON_TYPES = [int, float, text, bool, str]
 
 for regex in [ID, BOOL, INT, FLOAT, STRICTFLOAT, STRING]:
     regex.compile()


### PR DESCRIPTION
While using Python2, if a grammar can have multiple nested expressions, the exporter will fail to export these if Strings are present within them. 

Example.tx
```
Expression:
    ArithmeticExpression | SubExpression
;

ArithmeticExpression:
    operand=Operand (operator=Operator operand=Operand)+
;

SubExpression:
    leftParen="(" sub=Expression rightParen=")"
;

Operand:
    ID | INT | SubExpression
;

Operator:
    "+" | "-"
;
```

then using the string `(value + (exp + bla)) - blabla`

```
Python 2.7.15 (default, May  1 2018, 16:44:08)
[GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from textx import metamodel_from_file
>>> example_meta = metamodel_from_file('example.tx')
>>> my_string = "(value + (exp + bla)) - blabla"
>>> parsed = example_meta.model_from_str(my_string)
>>> from textx.export import model_export
>>> model_export("./", "my_file.dot")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/textx/export.py", line 163, in model_export
    model_export_to_file(f, model, repo)
  File "/usr/local/lib/python2.7/site-packages/textx/export.py", line 266, in model_export_to_file
    _export(model)
  File "/usr/local/lib/python2.7/site-packages/textx/export.py", line 194, in _export
    for attr_name, attr in obj_cls._tx_attrs.items():
AttributeError: type object 'str' has no attribute '_tx_attrs'
```

This bug only affects Python 2, Python 3 does not run into this error.