### PR TITLE
Feature (request): uniqueness checker

### DIFF
--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -108,6 +108,14 @@ We provide some standard scope providers:
    lookup.
    Example: see [tests/test_scoping/test_global_import_modules.py](https://github.com/igordejanovic/textX/blob/master/tests/functional/test_scoping/test_global_import_modules.py).
     - `textx.scoping.providers.FQNGlobalRepo` (decorated scope provider)
+       
+       Here, you can also activate the "importAs" feature to allow to make
+       imported models not visible in your root namespace, but related to
+       a named importURI element ([tests/test_scoping/importURI_variations/test_importURI_variations.py](https://github.com/igordejanovic/textX/blob/master/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py))
+       
+       You can also transform the importURI attribute to a filename:
+       see ([tests/test_scoping/importURI_variations/test_importURI_variations.py](https://github.com/igordejanovic/textX/blob/master/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py).
+       
     - `textx.scoping.providers.PlainNameGlobalRepo` (decorated scope provider)
  * `textx.scoping.providers.RelativeName`: This is a scope provider to **resolve
    relative lookups**: e.g., model-methods of a model-instance, defined by the

--- a/tests/functional/regressions/issue103/base.mod
+++ b/tests/functional/regressions/issue103/base.mod
@@ -1,0 +1,2 @@
+# imported module 'base.mod'
+class a {};

--- a/tests/functional/regressions/issue103/main.mod
+++ b/tests/functional/regressions/issue103/main.mod
@@ -1,0 +1,3 @@
+# main module
+import 'base.mod'
+var x = new base.a()

--- a/tests/functional/regressions/test_issue103_python_like_import.py
+++ b/tests/functional/regressions/test_issue103_python_like_import.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from textx import metamodel_from_str
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 import textx.scoping.providers as scoping_providers
 
 
@@ -39,7 +39,7 @@ def test_issue103_python_like_import():
     #################################
 
     m = mm.model_from_file(
-        abspath(dirname(__file__)) + "/issue103/main.mod")
+        join(abspath(dirname(__file__)), "issue103", "main.mod"))
 
     #################################
     # TEST MODEL

--- a/tests/functional/regressions/test_issue103_python_like_import.py
+++ b/tests/functional/regressions/test_issue103_python_like_import.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from textx import metamodel_from_str
 from os.path import dirname, abspath
-import textx.exceptions
 import textx.scoping.providers as scoping_providers
 
 
@@ -17,11 +16,8 @@ def test_issue103_python_like_import():
                 classes*=Class
                 vars*=Var
         ;
-        
         Class: 'class' name=ID '{' '}' ';';
-        
-        Var: 'var' name=ID '=' 'new' class=[Class|FQN] '(' ')';
-        
+        Var: 'var' name=ID '=' 'new' theclass=[Class|FQN] '(' ')';
         FQN: ID+['.'];
         Import: 'import' importURI=STRING;
         Comment: /#.*$/;
@@ -34,7 +30,8 @@ def test_issue103_python_like_import():
         return m.group(1)
 
     mm.register_scope_providers(
-        {"*.*": scoping_providers.FQNImportURI(importAs=True, name_setter=name_setter)})
+        {"*.*": scoping_providers.FQNImportURI(importAs=True,
+                                               name_setter=name_setter)})
 
     #################################
     # MODEL PARSING
@@ -47,7 +44,7 @@ def test_issue103_python_like_import():
     # TEST MODEL
     #################################
 
-    #assert my_model.packages[0].name == "B"
+    assert m.vars[0].theclass.name == "a"
 
     #################################
     # END

--- a/tests/functional/regressions/test_issue103_python_like_import.py
+++ b/tests/functional/regressions/test_issue103_python_like_import.py
@@ -24,10 +24,10 @@ def test_issue103_python_like_import():
         ''')
 
     def name_setter(import_obj):
-        import re
-        m = re.search(r'^([^\.]+).*$', import_obj.importURI)
-        assert m
-        return m.group(1)
+        # this method is responsible to deduce the module name in the
+        # language from the importURI string
+        # e.g. here: import "file.ext" --> module name "file".
+        return import_obj.importURI.split('.')[0]
 
     mm.register_scope_providers(
         {"*.*": scoping_providers.FQNImportURI(importAs=True,

--- a/tests/functional/regressions/test_issue103_python_like_import.py
+++ b/tests/functional/regressions/test_issue103_python_like_import.py
@@ -1,0 +1,54 @@
+from __future__ import unicode_literals
+
+from textx import metamodel_from_str
+from os.path import dirname, abspath
+import textx.exceptions
+import textx.scoping.providers as scoping_providers
+
+
+def test_issue103_python_like_import():
+    """
+    see issue 103 for a detailed error report
+    """
+
+    mm = metamodel_from_str(r'''
+        Model:
+                imports*=Import
+                classes*=Class
+                vars*=Var
+        ;
+        
+        Class: 'class' name=ID '{' '}' ';';
+        
+        Var: 'var' name=ID '=' 'new' class=[Class|FQN] '(' ')';
+        
+        FQN: ID+['.'];
+        Import: 'import' importURI=STRING;
+        Comment: /#.*$/;
+        ''')
+
+    def name_setter(import_obj):
+        import re
+        m = re.search(r'^([^\.]+).*$', import_obj.importURI)
+        assert m
+        return m.group(1)
+
+    mm.register_scope_providers(
+        {"*.*": scoping_providers.FQNImportURI(importAs=True, name_setter=name_setter)})
+
+    #################################
+    # MODEL PARSING
+    #################################
+
+    m = mm.model_from_file(
+        abspath(dirname(__file__)) + "/issue103/main.mod")
+
+    #################################
+    # TEST MODEL
+    #################################
+
+    #assert my_model.packages[0].name == "B"
+
+    #################################
+    # END
+    #################################

--- a/tests/functional/regressions/test_issue103_python_like_import.py
+++ b/tests/functional/regressions/test_issue103_python_like_import.py
@@ -23,15 +23,16 @@ def test_issue103_python_like_import():
         Comment: /#.*$/;
         ''')
 
-    def name_setter(import_obj):
+    def importURI_to_scope_name(import_obj):
         # this method is responsible to deduce the module name in the
         # language from the importURI string
         # e.g. here: import "file.ext" --> module name "file".
         return import_obj.importURI.split('.')[0]
 
     mm.register_scope_providers(
-        {"*.*": scoping_providers.FQNImportURI(importAs=True,
-                                               name_setter=name_setter)})
+        {"*.*": scoping_providers.
+            FQNImportURI(importAs=True,
+                         importURI_to_scope_name=importURI_to_scope_name)})
 
     #################################
     # MODEL PARSING

--- a/tests/functional/test_scoping/importURI_variations/importAs/b_error.model
+++ b/tests/functional/test_scoping/importURI_variations/importAs/b_error.model
@@ -1,0 +1,6 @@
+import folder.a as a
+
+package B {
+    object A1 "from B" ref packageA1.A
+    object A2 "from B" ref packageA2.A
+}

--- a/tests/functional/test_scoping/importURI_variations/importAs/b_multi_import.model
+++ b/tests/functional/test_scoping/importURI_variations/importAs/b_multi_import.model
@@ -1,0 +1,5 @@
+import folder.* as multi // imports "folder/a.model" and "folder/c.model"
+package B {
+    object A1 "from B" ref multi.packageA1.A
+    object A2 "from B" ref multi.packageC2.A
+}

--- a/tests/functional/test_scoping/importURI_variations/importAs/b_multi_import.model
+++ b/tests/functional/test_scoping/importURI_variations/importAs/b_multi_import.model
@@ -1,4 +1,4 @@
-import folder.* as multi // imports "folder/a.model" and "folder/c.model"
+import folder.* as multi  // imports "folder/a.model" and "folder/c.model"
 package B {
     object A1 "from B" ref multi.packageA1.A
     object A2 "from B" ref multi.packageC2.A

--- a/tests/functional/test_scoping/importURI_variations/importAs/b_ok1.model
+++ b/tests/functional/test_scoping/importURI_variations/importAs/b_ok1.model
@@ -1,0 +1,7 @@
+import folder.a as a // allows (2)
+import folder.a // allows (1)
+
+package B {
+    object A1 "from B" ref packageA1.A // (1)
+    object A2 "from B" ref a.packageA2.A // (2)
+}

--- a/tests/functional/test_scoping/importURI_variations/importAs/b_ok2.model
+++ b/tests/functional/test_scoping/importURI_variations/importAs/b_ok2.model
@@ -1,0 +1,5 @@
+import folder.a as a
+package B {
+    object A1 "from B" ref a.packageA1.A
+    object A2 "from B" ref a.packageA2.A
+}

--- a/tests/functional/test_scoping/importURI_variations/importAs/folder/a.model
+++ b/tests/functional/test_scoping/importURI_variations/importAs/folder/a.model
@@ -1,0 +1,8 @@
+package packageA1 {
+    object A "from A1";
+}
+package packageA2 {
+    object A "from A2" ref packageA1.A;
+    object B "from A2" ref A;
+    object C "from A2" ref packageA2.A;
+}

--- a/tests/functional/test_scoping/importURI_variations/importAs/folder/c.model
+++ b/tests/functional/test_scoping/importURI_variations/importAs/folder/c.model
@@ -1,0 +1,8 @@
+package packageC1 {
+    object A "from C1";
+}
+package packageC2 {
+    object A "from C2" ref packageC1.A;
+    object B "from C2" ref A;
+    object C "from C2" ref packageC2.A;
+}

--- a/tests/functional/test_scoping/importURI_variations/importStringHook/b.model
+++ b/tests/functional/test_scoping/importURI_variations/importStringHook/b.model
@@ -1,0 +1,6 @@
+import folder.a
+
+package B {
+    object A1 "from B" ref packageA1.A
+    object A2 "from B" ref packageA2.A
+}

--- a/tests/functional/test_scoping/importURI_variations/importStringHook/folder/a.model
+++ b/tests/functional/test_scoping/importURI_variations/importStringHook/folder/a.model
@@ -1,0 +1,8 @@
+package packageA1 {
+    object A "from A1";
+}
+package packageA2 {
+    object A "from A2" ref packageA1.A;
+    object B "from A2" ref A;
+    object C "from A2" ref packageA2.A;
+}

--- a/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
+++ b/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from textx import metamodel_from_str
 from os.path import dirname, abspath
 from pytest import raises
 import textx.exceptions
@@ -32,6 +33,7 @@ def test_importURI_variations_import_string_hook():
     #################################
     # END
     #################################
+
 
 def test_importURI_variations_import_as_ok1():
     #################################
@@ -110,4 +112,3 @@ def test_importURI_variations_import_as_error():
     #################################
     # END
     #################################
-

--- a/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
+++ b/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
@@ -13,8 +13,31 @@ def test_importURI_variations_import_string_hook():
     #################################
 
     my_meta_model = metamodel_from_str('''
-        TODO
+Model:
+        imports*=Import
+        packages*=Package
+;
+
+Package:
+        'package' name=ID '{'
+            objects*=Object
+        '}'
+;
+
+Object:
+    'object' name=ID text=STRING ('ref' ref=[Object|FQN])? ';'?
+;
+
+FQN: ID+['.'];
+Import: 'import' importURI=FQN;
+Comment: /\/\/.*$/;
     ''')
+
+    def conv(i):
+        return i.replace(".", "/")+".model"
+
+    my_meta_model.register_scope_providers(
+        {"*.*": scoping_providers.FQNImportURI(importURI_converter=conv)})
 
     #################################
     # MODEL PARSING
@@ -27,8 +50,11 @@ def test_importURI_variations_import_string_hook():
     # TEST MODEL
     #################################
 
-    pass
-    # TODO
+    assert my_model.packages[0].name == "B"
+    assert my_model.packages[0].objects[0].name == "A1"
+    assert my_model.packages[0].objects[0].ref.text == "from A1"
+    assert my_model.packages[0].objects[1].name == "A2"
+    assert my_model.packages[0].objects[1].ref.text == "from A2"
 
     #################################
     # END

--- a/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
+++ b/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
@@ -6,7 +6,7 @@ from pytest import raises
 import textx.exceptions
 import textx.scoping.providers as scoping_providers
 
-grammar = '''
+grammar = r'''
 Model:
         imports*=Import
         packages*=Package

--- a/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
+++ b/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
@@ -28,6 +28,7 @@ Import: 'import' importURI=FQNI ('as' name=ID)?;
 Comment: /\/\/.*$/;
 '''
 
+
 def test_importURI_variations_import_string_hook():
     #################################
     # META MODEL DEF

--- a/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
+++ b/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
@@ -1,0 +1,113 @@
+from __future__ import unicode_literals
+
+from os.path import dirname, abspath
+from pytest import raises
+import textx.exceptions
+import textx.scoping.providers as scoping_providers
+
+
+def test_importURI_variations_import_string_hook():
+    #################################
+    # META MODEL DEF
+    #################################
+
+    my_meta_model = metamodel_from_str('''
+        TODO
+    ''')
+
+    #################################
+    # MODEL PARSING
+    #################################
+
+    my_model = my_meta_model.model_from_file(
+        abspath(dirname(__file__)) + "/importStringHook/b.model")
+
+    #################################
+    # TEST MODEL
+    #################################
+
+    pass
+    # TODO
+
+    #################################
+    # END
+    #################################
+
+def test_importURI_variations_import_as_ok1():
+    #################################
+    # META MODEL DEF
+    #################################
+
+    my_meta_model = metamodel_from_str('''
+        TODO
+    ''')
+
+    #################################
+    # MODEL PARSING
+    #################################
+
+    my_model = my_meta_model.model_from_file(
+        abspath(dirname(__file__)) + "/importAs/b_ok1.model")
+
+    #################################
+    # TEST MODEL
+    #################################
+
+    pass
+    # TODO
+
+    #################################
+    # END
+    #################################
+
+
+def test_importURI_variations_import_as_ok2():
+    #################################
+    # META MODEL DEF
+    #################################
+
+    my_meta_model = metamodel_from_str('''
+        TODO
+    ''')
+
+    #################################
+    # MODEL PARSING
+    #################################
+
+    my_model = my_meta_model.model_from_file(
+        abspath(dirname(__file__)) + "/importAs/b_ok2.model")
+
+    #################################
+    # TEST MODEL
+    #################################
+
+    pass
+    # TODO
+
+    #################################
+    # END
+    #################################
+
+
+def test_importURI_variations_import_as_error():
+    #################################
+    # META MODEL DEF
+    #################################
+
+    my_meta_model = metamodel_from_str('''
+        TODO
+    ''')
+
+    #################################
+    # MODEL PARSING
+    #################################
+
+    my_model = my_meta_model.model_from_file(
+        abspath(dirname(__file__)) + "/importAs/b_ok2.model")
+
+    # TODO should raise error
+
+    #################################
+    # END
+    #################################
+

--- a/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
+++ b/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from textx import metamodel_from_str
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 from pytest import raises
 import textx.exceptions
 import textx.scoping.providers as scoping_providers
@@ -47,7 +47,7 @@ def test_importURI_variations_import_string_hook():
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/importStringHook/b.model")
+        join(abspath(dirname(__file__)), "importStringHook", "b.model"))
 
     #################################
     # TEST MODEL
@@ -83,7 +83,7 @@ def test_importURI_variations_import_as_ok1():
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/importAs/b_ok1.model")
+        join(abspath(dirname(__file__)), "importAs", "b_ok1.model"))
 
     #################################
     # TEST MODEL
@@ -119,7 +119,7 @@ def test_importURI_variations_import_as_ok2():
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/importAs/b_ok2.model")
+        join(abspath(dirname(__file__)), "importAs", "b_ok2.model"))
 
     #################################
     # TEST MODEL
@@ -155,7 +155,7 @@ def test_importURI_variations_import_as_multi_import():
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/importAs/b_multi_import.model")
+        join(abspath(dirname(__file__)), "importAs", "b_multi_import.model"))
 
     #################################
     # TEST MODEL
@@ -193,7 +193,7 @@ def test_importURI_variations_import_as_error():
     with raises(textx.exceptions.TextXSemanticError,
                 match=r'.*Unknown object.*packageA1.A.*'):
         my_meta_model.model_from_file(
-            abspath(dirname(__file__)) + "/importAs/b_error.model")
+            join(abspath(dirname(__file__)), "importAs", "b_error.model"))
 
     #################################
     # END

--- a/tests/functional/test_scoping/test_exception_from_included_model.py
+++ b/tests/functional/test_scoping/test_exception_from_included_model.py
@@ -43,11 +43,14 @@ def test_exception_from_included_model():
     import_lookup_provider = scoping_providers.FQNImportURI()
 
     a_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/A.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "A.tx"))
     b_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/B.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "B.tx"))
     c_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/C.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "C.tx"))
 
     scoping.MetaModelProvider.clear()
     scoping.MetaModelProvider.add_metamodel("*.a", a_mm)
@@ -62,7 +65,8 @@ def test_exception_from_included_model():
     with raises(textx.exceptions.TextXSemanticError,
                 match=r'.*model_d\.b:5:3:.*d1 triggers artifical error'):
         a_mm.model_from_file(
-            this_folder + "/metamodel_provider3/inheritance2/model_a.a")
+            join(this_folder, "metamodel_provider3",
+                 "inheritance2", "model_a.a"))
 
     #################################
     # END

--- a/tests/functional/test_scoping/test_full_qualified_name.py
+++ b/tests/functional/test_scoping/test_full_qualified_name.py
@@ -1,4 +1,4 @@
-from os.path import dirname
+from os.path import dirname, join
 
 from pytest import raises
 
@@ -119,8 +119,8 @@ def test_fully_qualified_name_ref():
                 match=r'.*test_fully_qualified_name_test_error.model:8:\d+:'
                       ' error.*Unknown object.*Part1.*'):
         my_metamodel.model_from_file(
-            dirname(__file__) +
-            "/misc/test_fully_qualified_name_test_error.model")
+            join(dirname(__file__),
+                 "misc", "test_fully_qualified_name_test_error.model"))
 
     #################################
     # END

--- a/tests/functional/test_scoping/test_global_import_modules.py
+++ b/tests/functional/test_scoping/test_global_import_modules.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 
 import textx.scoping.providers as scoping_providers
 from textx import metamodel_from_file
@@ -19,19 +19,23 @@ def test_globalimports_basic_test_with_single_model_file():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/interface_model2/Interface.tx')
+        join(abspath(dirname(__file__)), 'interface_model2',
+             'Interface.tx'))
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.FQNGlobalRepo(
-            abspath(dirname(__file__)) + "/interface_model2/model_a/*.if")})
+            join(abspath(dirname(__file__)), "interface_model2",
+                 "model_a", "*.if"))})
 
     #################################
     # MODEL PARSING
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/interface_model2/model_a/all_in_one.if")
+        join(abspath(dirname(__file__)), "interface_model2",
+             "model_a", "all_in_one.if"))
     my_model2 = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/interface_model2/model_a/all_in_one.if")
+        join(abspath(dirname(__file__)), "interface_model2",
+             "model_a", "all_in_one.if"))
 
     #################################
     # TEST MODEL
@@ -64,20 +68,24 @@ def test_globalimports_basic_test_with_single_model_file_and_global_repo():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/interface_model2/Interface.tx',
+        join(abspath(dirname(__file__)), 'interface_model2',
+             'Interface.tx'),
         global_repository=True)
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.FQNGlobalRepo(
-            abspath(dirname(__file__)) + "/interface_model2/model_a/*.if")})
+            join(abspath(dirname(__file__)), 'interface_model2',
+                 'model_a', '*.if'))})
 
     #################################
     # MODEL PARSING
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/interface_model2/model_a/all_in_one.if")
+        join(abspath(dirname(__file__)), "interface_model2",
+             "model_a", "all_in_one.if"))
     my_model2 = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/interface_model2/model_a/all_in_one.if")
+        join(abspath(dirname(__file__)), "interface_model2",
+             "model_a", "all_in_one.if"))
 
     #################################
     # TEST MODEL
@@ -110,17 +118,20 @@ def test_globalimports_basic_test_with_distributed_model():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/interface_model2/Interface.tx')
+        join(abspath(dirname(__file__)),
+             'interface_model2', 'Interface.tx'))
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.FQNGlobalRepo(
-            abspath(dirname(__file__)) + "/interface_model2/model_b/*.if")})
+            join(abspath(dirname(__file__)),
+                 "interface_model2", "model_b", "*.if"))})
 
     #################################
     # MODEL PARSING
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/interface_model2/model_b/app.if")
+        join(abspath(dirname(__file__)),
+             "interface_model2", "model_b", "app.if"))
 
     #################################
     # TEST MODEL
@@ -128,7 +139,8 @@ def test_globalimports_basic_test_with_distributed_model():
 
     # check that "socket" is an interface
     inner_model = my_model._tx_model_repository.all_models.filename_to_model[
-        abspath(dirname(__file__)) + "/interface_model2/model_b/base.if"]
+        join(abspath(dirname(__file__)),
+             "interface_model2", "model_b", "base.if")]
     check_unique_named_object_has_class(inner_model, "socket", "Interface")
 
     # check that "s.s1" is a reference to the socket interface

--- a/tests/functional/test_scoping/test_import_module.py
+++ b/tests/functional/test_scoping/test_import_module.py
@@ -185,7 +185,8 @@ def test_model_with_circular_imports():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/interface_model1/Interface.tx')
+        join(abspath(dirname(__file__)),
+             'interface_model1', 'Interface.tx'))
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.FQNImportURI()})
 
@@ -194,7 +195,8 @@ def test_model_with_circular_imports():
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/interface_model1/model_c/A.if")
+        join(abspath(dirname(__file__)),
+             "interface_model1", "model_c", "A.if"))
 
     #################################
     # TEST MODEL
@@ -247,7 +249,8 @@ def test_model_with_multi_import():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/interface_model1/Interface.tx')
+        join(abspath(dirname(__file__)),
+             'interface_model1', 'Interface.tx'))
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.FQNImportURI()})
 
@@ -256,8 +259,8 @@ def test_model_with_multi_import():
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) +
-        "/interface_model1/model_c/A_multi_import.if")
+        join(abspath(dirname(__file__)),
+             "interface_model1", "model_c", "A_multi_import.if"))
 
     #################################
     # TEST MODEL

--- a/tests/functional/test_scoping/test_import_module.py
+++ b/tests/functional/test_scoping/test_import_module.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 
 from pytest import raises
 
@@ -21,7 +21,8 @@ def test_model_without_imports():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/interface_model1/Interface.tx')
+        join(abspath(dirname(__file__)),
+             'interface_model1', 'Interface.tx'))
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.FQNImportURI()})
 
@@ -30,7 +31,8 @@ def test_model_without_imports():
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/interface_model1/model_a/all_in_one.if")
+        join(abspath(dirname(__file__)),
+             "interface_model1", "model_a", "all_in_one.if"))
 
     #################################
     # TEST MODEL
@@ -58,7 +60,8 @@ def test_model_with_imports():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/interface_model1/Interface.tx')
+        join(abspath(dirname(__file__)),
+             'interface_model1', 'Interface.tx'))
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.FQNImportURI()})
 
@@ -67,9 +70,11 @@ def test_model_with_imports():
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/interface_model1/model_b/app.if")
+        join(abspath(dirname(__file__)),
+             "interface_model1", "model_b", "app.if"))
     my_model2 = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/interface_model1/model_b/app.if")
+        join(abspath(dirname(__file__)),
+             "interface_model1", "model_b", "app.if"))
 
     #################################
     # TEST MODEL
@@ -77,7 +82,8 @@ def test_model_with_imports():
 
     # check that "socket" is an interface
     inner_model = my_model._tx_model_repository.all_models.filename_to_model[
-        abspath(dirname(__file__)) + "/interface_model1/model_b/base.if"]
+        join(abspath(dirname(__file__)),
+             "interface_model1", "model_b", "base.if")]
     check_unique_named_object_has_class(inner_model, "socket", "Interface")
 
     # check that "s.s1" is a reference to the socket interface
@@ -105,7 +111,8 @@ def test_model_with_imports_and_errors():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/interface_model1/Interface.tx')
+        join(abspath(dirname(__file__)),
+             'interface_model1', 'Interface.tx'))
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.FQNImportURI()})
 
@@ -116,13 +123,13 @@ def test_model_with_imports_and_errors():
     with raises(textx.exceptions.TextXSemanticError,
                 match=r'.*Unknown object.*types.int.*'):
         my_meta_model.model_from_file(
-            abspath(dirname(__file__)) +
-            "/interface_model1/model_b/app_error1.if")
+            join(abspath(dirname(__file__)),
+                 "interface_model1", "model_b", "app_error1.if"))
 
     with raises(IOError, match=r'.*file_not_found\.if.*'):
         my_meta_model.model_from_file(
-            abspath(dirname(__file__)) +
-            "/interface_model1/model_b/app_error2.if")
+            join(abspath(dirname(__file__)),
+                 "interface_model1", "model_b", "app_error2.if"))
 
     #################################
     # END
@@ -138,7 +145,7 @@ def test_model_with_imports_and_global_repo():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/interface_model1/Interface.tx',
+        join(abspath(dirname(__file__)), 'interface_model1', 'Interface.tx'),
         global_repository=True)
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.FQNImportURI()})
@@ -148,9 +155,11 @@ def test_model_with_imports_and_global_repo():
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/interface_model1/model_b/app.if")
+        join(abspath(dirname(__file__)),
+             "interface_model1", "model_b", "app.if"))
     my_model2 = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/interface_model1/model_b/app.if")
+        join(abspath(dirname(__file__)),
+             "interface_model1", "model_b", "app.if"))
 
     #################################
     # TEST MODEL

--- a/tests/functional/test_scoping/test_import_module_search_path_issue66.py
+++ b/tests/functional/test_scoping/test_import_module_search_path_issue66.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 import textx.scoping.providers as scoping_providers
 from textx import metamodel_from_file
 from pytest import raises
@@ -15,7 +15,7 @@ def test_model_with_imports_and_search_path_bad_case1():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/issue66/task_specification.tx')
+        join(abspath(dirname(__file__)), 'issue66', 'task_specification.tx'))
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.PlainNameImportURI()})
 
@@ -25,7 +25,7 @@ def test_model_with_imports_and_search_path_bad_case1():
 
     with raises(IOError, match=r'.*lib.*tasks.*'):
         my_meta_model.model_from_file(
-            abspath(dirname(__file__)) + "/issue66/assembly_car1.prog")
+            join(abspath(dirname(__file__)), "issue66", "assembly_car1.prog"))
 
     #################################
     # END
@@ -41,10 +41,10 @@ def test_model_with_imports_and_search_path_good_case():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/issue66/task_specification.tx')
+        join(abspath(dirname(__file__)), 'issue66', 'task_specification.tx'))
     search_path = [
-        abspath(dirname(__file__)) + '/issue66/somewhere1',
-        abspath(dirname(__file__)) + '/issue66/somewhere2'
+        join(abspath(dirname(__file__)), 'issue66', 'somewhere1'),
+        join(abspath(dirname(__file__)), 'issue66', 'somewhere2')
     ]
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.PlainNameImportURI(search_path=search_path)})
@@ -54,7 +54,7 @@ def test_model_with_imports_and_search_path_good_case():
     #################################
 
     my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/issue66/assembly_car1.prog")
+        join(abspath(dirname(__file__)), "issue66", "assembly_car1.prog"))
 
     #################################
     # END
@@ -70,10 +70,10 @@ def test_model_with_imports_and_search_path_bad_case2a():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/issue66/task_specification.tx')
+        join(abspath(dirname(__file__)), 'issue66', 'task_specification.tx'))
     search_path = [
-        abspath(dirname(__file__)) + '/issue66/somewhere1',  # assembly
-        abspath(dirname(__file__)) + '/issue66/somewhere2xx'  # position
+        join(abspath(dirname(__file__)), 'issue66', 'somewhere1'),  # assembly
+        join(abspath(dirname(__file__)), 'issue66', 'somewhere2xx')  # position
     ]
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.PlainNameImportURI(search_path=search_path)})
@@ -84,7 +84,7 @@ def test_model_with_imports_and_search_path_bad_case2a():
 
     with raises(IOError, match=r'.*position\.tasks.*'):
         my_meta_model.model_from_file(
-            abspath(dirname(__file__)) + "/issue66/assembly_car1.prog")
+            join(abspath(dirname(__file__)), "issue66", "assembly_car1.prog"))
 
     #################################
     # END
@@ -100,10 +100,13 @@ def test_model_with_imports_and_search_path_bad_case2b():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/issue66/task_specification.tx')
+        join(abspath(dirname(__file__)), 'issue66',
+             'task_specification.tx'))
     search_path = [
-        abspath(dirname(__file__)) + '/issue66/somewhere1xx',  # assembly
-        abspath(dirname(__file__)) + '/issue66/somewhere2'  # position
+        join(abspath(dirname(__file__)), 'issue66',
+             'somewhere1xx'),  # assembly
+        join(abspath(dirname(__file__)), 'issue66',
+             'somewhere2')  # position
     ]
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.PlainNameImportURI(search_path=search_path)})
@@ -114,7 +117,7 @@ def test_model_with_imports_and_search_path_bad_case2b():
 
     with raises(IOError, match=r'.*assembly\.tasks.*'):
         my_meta_model.model_from_file(
-            abspath(dirname(__file__)) + "/issue66/assembly_car1.prog")
+            join(abspath(dirname(__file__)), "issue66", "assembly_car1.prog"))
 
     #################################
     # END
@@ -130,10 +133,10 @@ def test_model_with_imports_and_search_path_bad_case_search_and_glob1():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/issue66/task_specification.tx')
+        join(abspath(dirname(__file__)), 'issue66', 'task_specification.tx'))
     search_path = [
-        abspath(dirname(__file__)) + '/issue66/somewhere1',  # assembly
-        abspath(dirname(__file__)) + '/issue66/somewhere2'  # position
+        join(abspath(dirname(__file__)), 'issue66', 'somewhere1'),  # assembly
+        join(abspath(dirname(__file__)), 'issue66', 'somewhere2')  # position
     ]
     with raises(Exception,
                 match=r'you cannot use globbing together with a search path'):
@@ -156,10 +159,10 @@ def test_model_with_imports_and_search_path_bad_case_search_and_glob2():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/issue66/task_specification.tx')
+        join(abspath(dirname(__file__)), 'issue66', 'task_specification.tx'))
     search_path = [
-        abspath(dirname(__file__)) + '/issue66/somewhere1',  # assembly
-        abspath(dirname(__file__)) + '/issue66/somewhere2'   # position
+        join(abspath(dirname(__file__)), 'issue66', 'somewhere1'),  # assembly
+        join(abspath(dirname(__file__)), 'issue66', 'somewhere2')   # position
     ]
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.PlainNameImportURI(search_path=search_path)})
@@ -170,7 +173,7 @@ def test_model_with_imports_and_search_path_bad_case_search_and_glob2():
 
     with raises(IOError, match=r'.*assembly\.\*.*'):
         my_meta_model.model_from_file(
-            abspath(dirname(__file__)) + "/issue66/assembly_car2.prog")
+            join(abspath(dirname(__file__)), "issue66", "assembly_car2.prog"))
 
     #################################
     # END
@@ -187,10 +190,10 @@ def test_model_with_imports_relative_to_current_model():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/issue66/task_specification.tx')
+        join(abspath(dirname(__file__)), 'issue66', 'task_specification.tx'))
     search_path = [
-        abspath(dirname(__file__)) + '/issue66/somewhere1',  # assembly
-        abspath(dirname(__file__)) + '/issue66/somewhere2'   # position
+        join(abspath(dirname(__file__)), 'issue66', 'somewhere1'),  # assembly
+        join(abspath(dirname(__file__)), 'issue66', 'somewhere2')   # position
     ]
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.PlainNameImportURI(search_path=search_path)})
@@ -204,7 +207,8 @@ def test_model_with_imports_relative_to_current_model():
     #   be preferred.
     # * on only exists locally.
     m = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/issue66/local/assembly_car3.prog")
+        join(abspath(dirname(__file__)),
+             'issue66', 'local', 'assembly_car3.prog'))
 
     # the model could be loaded --> the local path works (one file exists
     # only locally).

--- a/tests/functional/test_scoping/test_inheritance.py
+++ b/tests/functional/test_scoping/test_inheritance.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 import re
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 
 import textx.scoping.providers as scoping_providers
 from textx import get_children_of_type
@@ -35,8 +35,8 @@ def test_inheritance_processor():
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) +
-        "/components_model1/example_inherit3.components")
+        join(abspath(dirname(__file__)),
+             "components_model1", "example_inherit3.components"))
 
     #################################
     # TEST MODEL

--- a/tests/functional/test_scoping/test_inheritance.py
+++ b/tests/functional/test_scoping/test_inheritance.py
@@ -17,7 +17,8 @@ def test_inheritance_processor():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/components_model1/Components.tx')
+        join(abspath(dirname(__file__)),
+             'components_model1', 'Components.tx'))
     my_meta_model.register_scope_providers({
         "*.*": scoping_providers.FQN(),
         "Connection.from_port":

--- a/tests/functional/test_scoping/test_local_scope.py
+++ b/tests/functional/test_scoping/test_local_scope.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 
 from pytest import raises
 
@@ -29,7 +29,8 @@ def test_postponed_resolution_error():
         return scoping.Postponed()
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/components_model1/Components.tx')
+        join(abspath(dirname(__file__)),
+             'components_model1', 'Components.tx'))
     my_meta_model.register_scope_providers({
         "*.*": scoping_providers.FQN(),
         "Connection.from_port": from_port,
@@ -43,8 +44,8 @@ def test_postponed_resolution_error():
     with raises(textx.exceptions.TextXSemanticError,
                 match=r'.*Unresolvable cross references.*'):
         my_meta_model.model_from_file(
-            abspath(dirname(__file__)) +
-            "/components_model1/example.components")
+            join(abspath(dirname(__file__)),
+                 "components_model1", "example.components"))
 
 
 def test_model_with_local_scope():
@@ -70,7 +71,8 @@ def test_model_with_local_scope():
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/components_model1/example.components")
+        join(abspath(dirname(__file__)), "components_model1",
+             "example.components"))
 
     #################################
     # TEST MODEL
@@ -124,8 +126,8 @@ def test_model_with_local_scope_and_error():
     with raises(textx.exceptions.TextXSemanticError,
                 match=r'.*Unknown objec.*input1.*SlotIn.*'):
         my_meta_model.model_from_file(
-            abspath(dirname(__file__)) +
-            "/components_model1/example_err1.components")
+            join(abspath(dirname(__file__)),
+                 "components_model1", "example_err1.components"))
 
     #################################
     # END
@@ -159,8 +161,8 @@ def test_model_with_local_scope_and_inheritance2():
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) +
-        "/components_model1/example_inherit1.components")
+        join(abspath(dirname(__file__)),
+             "components_model1", "example_inherit1.components"))
 
     #################################
     # TEST MODEL
@@ -188,8 +190,8 @@ def test_model_with_local_scope_and_inheritance2():
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) +
-        "/components_model1/example_inherit2.components")
+        join(abspath(dirname(__file__)),
+             "components_model1", "example_inherit2.components"))
 
     #################################
     # TEST MODEL
@@ -258,10 +260,10 @@ def test_model_with_local_scope_postponed():
     # MODEL PARSING
     #################################
 
-    my_meta_model1.model_from_file(abspath(dirname(__file__)) +
-                                   "/components_model1/example.components")
-    my_meta_model2.model_from_file(abspath(dirname(__file__)) +
-                                   "/components_model2/example.components")
+    my_meta_model1.model_from_file(join(abspath(dirname(__file__)),
+                                   "components_model1", "example.components"))
+    my_meta_model2.model_from_file(join(abspath(dirname(__file__)),
+                                   "components_model2", "example.components"))
 
     #################################
     # TEST MODEL
@@ -284,7 +286,8 @@ def test_model_with_local_scope_wrong_type():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/components_model1/Components.tx')
+        join(abspath(dirname(__file__)),
+             'components_model1', 'Components.tx'))
     my_meta_model.register_scope_providers({
         "*.*": scoping_providers.FQN(),
         "Connection.from_port":
@@ -300,5 +303,5 @@ def test_model_with_local_scope_wrong_type():
     with raises(textx.exceptions.TextXSemanticError,
                 match=r'.*wrong_port.*'):
         my_meta_model.model_from_file(
-            abspath(dirname(__file__))
-            + "/components_model1/example_wrong_type.components")
+            join(abspath(dirname(__file__)),
+                 "components_model1", "example_wrong_type.components"))

--- a/tests/functional/test_scoping/test_local_scope.py
+++ b/tests/functional/test_scoping/test_local_scope.py
@@ -57,7 +57,8 @@ def test_model_with_local_scope():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/components_model1/Components.tx')
+        join(abspath(dirname(__file__)), 'components_model1',
+             'Components.tx'))
     my_meta_model.register_scope_providers({
         "*.*": scoping_providers.FQN(),
         "Connection.from_port":
@@ -110,7 +111,8 @@ def test_model_with_local_scope_and_error():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/components_model1/Components.tx')
+        join(abspath(dirname(__file__)), 'components_model1',
+             'Components.tx'))
     my_meta_model.register_scope_providers({
         "*.*": scoping_providers.FQN(),
         "Connection.from_port":
@@ -143,7 +145,8 @@ def test_model_with_local_scope_and_inheritance2():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/components_model1/Components.tx')
+        join(abspath(dirname(__file__)), 'components_model1',
+             'Components.tx'))
     my_meta_model.register_scope_providers({
         "*.*": scoping_providers.FQN(),
         "Connection.from_port":
@@ -238,7 +241,8 @@ def test_model_with_local_scope_postponed():
 
     sp1 = scoping_providers.RelativeName("from_inst.component.slots")
     my_meta_model1 = metamodel_from_file(
-        abspath(dirname(__file__)) + '/components_model1/Components.tx')
+        join(abspath(dirname(__file__)),
+             'components_model1', 'Components.tx'))
     my_meta_model1.register_scope_providers({
         "*.*": scoping_providers.FQN(),
         "Connection.from_port": sp1,
@@ -247,8 +251,9 @@ def test_model_with_local_scope_postponed():
     })
 
     sp2 = scoping_providers.RelativeName("from_inst.component.slots")
-    my_meta_model2 = metamodel_from_file(abspath(dirname(__file__)) +
-                                         '/components_model2/Components.tx')
+    my_meta_model2 = metamodel_from_file(
+        join(abspath(dirname(__file__)), 'components_model2',
+             'Components.tx'))
     my_meta_model2.register_scope_providers({
         "*.*": scoping_providers.FQN(),
         "Connection.from_port": sp2,

--- a/tests/functional/test_scoping/test_local_scope_circular.py
+++ b/tests/functional/test_scoping/test_local_scope_circular.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 
 import textx.scoping.providers as scoping_providers
 from textx import get_children_of_type
@@ -17,10 +17,12 @@ def test_model_with_local_scope_and_circular_ref_via_two_models():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/components_model1/Components.tx',
+        join(abspath(dirname(__file__)),
+             'components_model1', 'Components.tx'),
         global_repository=True)
     global_scope = scoping_providers.FQNGlobalRepo(
-        abspath(dirname(__file__)) + "/components_model1/example_?.components")
+        join(abspath(dirname(__file__)),
+             "components_model1", "example_?.components"))
     my_meta_model.register_scope_providers({
         "*.*": global_scope,
         "Connection.from_port":
@@ -34,9 +36,11 @@ def test_model_with_local_scope_and_circular_ref_via_two_models():
     #################################
 
     my_model_a = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/components_model1/example_A.components")
+        join(abspath(dirname(__file__)),
+             "components_model1", "example_A.components"))
     my_model_b = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) + "/components_model1/example_B.components")
+        join(abspath(dirname(__file__)),
+             "components_model1", "example_B.components"))
 
     a_my_a = get_unique_named_object(my_model_a, "mya")
     a_my_b = get_unique_named_object(my_model_a, "myb")

--- a/tests/functional/test_scoping/test_metamodel_provider.py
+++ b/tests/functional/test_scoping/test_metamodel_provider.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 
 from pytest import raises
 
@@ -23,7 +23,8 @@ def test_metamodel_provider_basic_test():
     #################################
 
     mm_components = metamodel_from_file(
-        abspath(dirname(__file__)) + '/metamodel_provider/Components.tx')
+        join(abspath(dirname(__file__)),
+             'metamodel_provider', 'Components.tx'))
     mm_components.register_scope_providers({
         "*.*": scoping_providers.FQNImportURI(),
         "Connection.from_port":
@@ -33,7 +34,7 @@ def test_metamodel_provider_basic_test():
     })
 
     mm_users = metamodel_from_file(
-        abspath(dirname(__file__)) + '/metamodel_provider/Users.tx')
+        join(abspath(dirname(__file__)), 'metamodel_provider', 'Users.tx'))
     mm_users.register_scope_providers({
         "*.*": scoping_providers.FQNImportURI(),
     })
@@ -48,7 +49,8 @@ def test_metamodel_provider_basic_test():
     #################################
 
     my_model = mm_users.model_from_file(
-        abspath(dirname(__file__)) + "/metamodel_provider/example.users")
+        join(abspath(dirname(__file__)),
+             "metamodel_provider", "example.users"))
 
     #################################
     # TEST MODEL

--- a/tests/functional/test_scoping/test_metamodel_provider2.py
+++ b/tests/functional/test_scoping/test_metamodel_provider2.py
@@ -34,14 +34,14 @@ def test_metamodel_provider_advanced_test():
 
     global_repo = scoping_providers.PlainNameGlobalRepo()
     global_repo.register_models(
-        this_folder + "/metamodel_provider2/*.recipe")
+        join(this_folder, "metamodel_provider2", "*.recipe"))
     global_repo.register_models(
-        this_folder + "/metamodel_provider2/*.ingredient")
+        join(this_folder, "metamodel_provider2", "*.ingredient"))
 
     i_mm = get_meta_model(
-        global_repo, this_folder + "/metamodel_provider2/Ingredient.tx")
+        global_repo, join(this_folder, "metamodel_provider2", "Ingredient.tx"))
     r_mm = get_meta_model(
-        global_repo, this_folder + "/metamodel_provider2/Recipe.tx")
+        global_repo, join(this_folder, "metamodel_provider2", "Recipe.tx"))
 
     scoping.MetaModelProvider.add_metamodel("*.recipe", r_mm)
     scoping.MetaModelProvider.add_metamodel("*.ingredient", i_mm)

--- a/tests/functional/test_scoping/test_metamodel_provider3.py
+++ b/tests/functional/test_scoping/test_metamodel_provider3.py
@@ -31,18 +31,21 @@ def test_metamodel_provider_advanced_test3_global():
 
     global_repo_provider = scoping_providers.PlainNameGlobalRepo()
     global_repo_provider.register_models(
-        this_folder + "/metamodel_provider3/circular/*.a")
+        join(this_folder, "metamodel_provider3", "circular", "*.a"))
     global_repo_provider.register_models(
-        this_folder + "/metamodel_provider3/circular/*.b")
+        join(this_folder, "metamodel_provider3", "circular", "*.b"))
     global_repo_provider.register_models(
-        this_folder + "/metamodel_provider3/circular/*.c")
+        join(this_folder, "metamodel_provider3", "circular", "*.c"))
 
     a_mm = get_meta_model(
-        global_repo_provider, this_folder + "/metamodel_provider3/A.tx")
+        global_repo_provider, join(this_folder,
+                                   "metamodel_provider3", "A.tx"))
     b_mm = get_meta_model(
-        global_repo_provider, this_folder + "/metamodel_provider3/B.tx")
+        global_repo_provider, join(this_folder,
+                                   "metamodel_provider3", "B.tx"))
     c_mm = get_meta_model(
-        global_repo_provider, this_folder + "/metamodel_provider3/C.tx")
+        global_repo_provider, join(this_folder,
+                                   "metamodel_provider3", "C.tx"))
 
     scoping.MetaModelProvider.clear()
     scoping.MetaModelProvider.add_metamodel("*.a", a_mm)
@@ -114,11 +117,14 @@ def test_metamodel_provider_advanced_test3_import():
     import_lookup_provider = scoping_providers.PlainNameImportURI()
 
     a_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/A.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "A.tx"))
     b_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/B.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "B.tx"))
     c_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/C.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "C.tx"))
 
     scoping.MetaModelProvider.clear()
     scoping.MetaModelProvider.add_metamodel("*.a", a_mm)
@@ -130,7 +136,7 @@ def test_metamodel_provider_advanced_test3_import():
     #################################
 
     m = a_mm.model_from_file(
-        this_folder + "/metamodel_provider3/circular/model_a.a")
+        join(this_folder, "metamodel_provider3", "circular", "model_a.a"))
     model_repo = m._tx_model_repository.all_models
 
     #################################
@@ -188,11 +194,14 @@ def test_metamodel_provider_advanced_test3_inheritance():
     import_lookup_provider = scoping_providers.FQNImportURI()
 
     a_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/A.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "A.tx"))
     b_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/B.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "B.tx"))
     c_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/C.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "C.tx"))
 
     scoping.MetaModelProvider.clear()
     scoping.MetaModelProvider.add_metamodel("*.a", a_mm)
@@ -204,7 +213,8 @@ def test_metamodel_provider_advanced_test3_inheritance():
     #################################
 
     m = a_mm.model_from_file(
-        this_folder + "/metamodel_provider3/inheritance/model_a.a")
+        join(this_folder, "metamodel_provider3",
+             "inheritance", "model_a.a"))
     model_repo = m._tx_model_repository.all_models
 
     #################################
@@ -255,11 +265,14 @@ def test_metamodel_provider_advanced_test3_inheritance2():
     import_lookup_provider = scoping_providers.FQNImportURI()
 
     a_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/A.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "A.tx"))
     b_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/B.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "B.tx"))
     c_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/C.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "C.tx"))
 
     scoping.MetaModelProvider.clear()
     scoping.MetaModelProvider.add_metamodel("*.a", a_mm)
@@ -271,7 +284,8 @@ def test_metamodel_provider_advanced_test3_inheritance2():
     #################################
 
     m = a_mm.model_from_file(
-        this_folder + "/metamodel_provider3/inheritance2/model_a.a")
+        join(this_folder, "metamodel_provider3",
+             "inheritance2", "model_a.a"))
     model_repo = m._tx_model_repository.all_models
 
     #################################
@@ -330,11 +344,14 @@ def test_metamodel_provider_advanced_test3_diamond():
     import_lookup_provider = scoping_providers.FQNImportURI()
 
     a_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/A.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "A.tx"))
     b_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/B.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "B.tx"))
     c_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/C.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "C.tx"))
 
     scoping.MetaModelProvider.clear()
     scoping.MetaModelProvider.add_metamodel("*.a", a_mm)
@@ -346,7 +363,8 @@ def test_metamodel_provider_advanced_test3_diamond():
     #################################
 
     m = a_mm.model_from_file(
-        this_folder + "/metamodel_provider3/diamond/A_includes_B_C.a")
+        join(this_folder, "metamodel_provider3",
+             "diamond", "A_includes_B_C.a"))
     model_repo = m._tx_model_repository.all_models
 
     #################################

--- a/tests/functional/test_scoping/test_metamodel_provider_utf_16_le.py
+++ b/tests/functional/test_scoping/test_metamodel_provider_utf_16_le.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 
 import textx.scoping as scoping
 import textx.scoping.providers as scoping_providers
@@ -18,8 +18,8 @@ def test_metamodel_provider_utf_16_le_basic_test():
     #################################
 
     mm_components = metamodel_from_file(
-        abspath(dirname(__file__)) +
-        '/metamodel_provider_utf-16-le/Components.tx')
+        join(abspath(dirname(__file__)),
+             'metamodel_provider_utf-16-le', 'Components.tx'))
     mm_components.register_scope_providers({
         "*.*": scoping_providers.FQNImportURI(),
         "Connection.from_port":
@@ -29,7 +29,8 @@ def test_metamodel_provider_utf_16_le_basic_test():
     })
 
     mm_users = metamodel_from_file(
-        abspath(dirname(__file__)) + '/metamodel_provider_utf-16-le/Users.tx')
+        join(abspath(dirname(__file__)),
+             'metamodel_provider_utf-16-le', 'Users.tx'))
     mm_users.register_scope_providers({
         "*.*": scoping_providers.FQNImportURI(),
     })
@@ -42,8 +43,9 @@ def test_metamodel_provider_utf_16_le_basic_test():
     #################################
 
     my_model = mm_users.model_from_file(
-        abspath(dirname(__file__)) +
-        "/metamodel_provider_utf-16-le/example.users", encoding='utf-16-le')
+        join(abspath(dirname(__file__)),
+             "metamodel_provider_utf-16-le", "example.users"),
+        encoding='utf-16-le')
 
     #################################
     # TEST MODEL

--- a/tests/functional/test_scoping/test_model_export.py
+++ b/tests/functional/test_scoping/test_model_export.py
@@ -36,11 +36,14 @@ def test_model_export():
     import_lookup_provider = scoping_providers.FQNImportURI()
 
     a_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/A.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "A.tx"))
     b_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/B.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "B.tx"))
     c_mm = get_meta_model(
-        import_lookup_provider, this_folder + "/metamodel_provider3/C.tx")
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "C.tx"))
 
     scoping.MetaModelProvider.clear()
     scoping.MetaModelProvider.add_metamodel("*.a", a_mm)
@@ -52,7 +55,8 @@ def test_model_export():
     #################################
 
     m = a_mm.model_from_file(
-        this_folder + "/metamodel_provider3/inheritance/model_a.a")
+        join(this_folder, "metamodel_provider3",
+             "inheritance", "model_a.a"))
 
     out_file = io.StringIO()
     # export.model_export(

--- a/tests/functional/test_scoping/test_reference_to_nontextx_attribute.py
+++ b/tests/functional/test_scoping/test_reference_to_nontextx_attribute.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from textx import metamodel_from_str
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 from pytest import raises
 from textx.scoping.tools import get_unique_named_object
 
@@ -32,7 +32,7 @@ def test_reference_to_nontextx_attribute():
         if not hasattr(obj.pyobj, "data"):
             import json
             obj.pyobj.data = json.load(open(
-                abspath(dirname(__file__)) + "/" + obj.pyobj.filename))
+                join(abspath(dirname(__file__)), obj.pyobj.filename)))
         if attr_ref.obj_name in obj.pyobj.data:
             return obj.pyobj.data[attr_ref.obj_name]
         else:

--- a/tests/functional/test_scoping/test_scoping_tools.py
+++ b/tests/functional/test_scoping/test_scoping_tools.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 
 import textx.scoping.providers as scoping_providers
 from textx import metamodel_from_file, metamodel_from_str
@@ -37,7 +37,8 @@ def test_get_referenced_object():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/components_model1/Components.tx')
+        join(abspath(dirname(__file__)),
+             'components_model1', 'Components.tx'))
     my_meta_model.register_scope_providers({
         "*.*": scoping_providers.FQN(),
         "Connection.from_port":
@@ -55,8 +56,8 @@ def test_get_referenced_object():
     #################################
 
     my_model = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) +
-        "/components_model1/example_inherit2.components")
+        join(abspath(dirname(__file__)),
+             "components_model1", "example_inherit2.components"))
 
     #################################
     # TEST MODEL
@@ -79,7 +80,8 @@ def test_get_list_of_concatenated_objects():
     #################################
 
     my_meta_model = metamodel_from_file(
-        abspath(dirname(__file__)) + '/components_model1/Components.tx')
+        join(abspath(dirname(__file__)),
+             'components_model1', 'Components.tx'))
     my_meta_model.register_scope_providers({
         "*.*": scoping_providers.FQN(),
         "Connection.from_port":
@@ -97,11 +99,11 @@ def test_get_list_of_concatenated_objects():
     #################################
 
     my_model1 = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) +
-        "/components_model1/example_inherit1.components")
+        join(abspath(dirname(__file__)),
+             "components_model1", "example_inherit1.components"))
     my_model2 = my_meta_model.model_from_file(
-        abspath(dirname(__file__)) +
-        "/components_model1/example_inherit2.components")
+        join(abspath(dirname(__file__)),
+             "components_model1", "example_inherit2.components"))
 
     #################################
     # TEST MODEL

--- a/tests/functional/test_uniq_chk.py
+++ b/tests/functional/test_uniq_chk.py
@@ -1,0 +1,89 @@
+import pytest
+
+from textx import metamodel_from_str
+from textx.uniq_chk import uniq_chk
+from textx.exceptions import TextXSemanticError
+
+
+# adapter from entity example
+grammar = """
+EntityModel:
+    entities+=Entity
+;
+
+Entity:
+    'entity' name=ID '{'
+        properties*=Property
+    '}'
+;
+
+Type:
+    'int' | 'string' | 'float'
+;
+
+Property:
+    name=ID ':' type=Type
+;
+"""
+
+def uniq_chk_entities(x):
+    uniq_chk(x, 'entities')
+
+def uniq_chk_properties(x):
+    uniq_chk(x, 'properties')
+
+def test_multiple_objects_model_level():
+    """
+    Test that model children uniqueness is validated.
+    """
+    metamodel = metamodel_from_str(grammar)
+    metamodel.register_obj_processors({
+        'EntityModel': uniq_chk_entities,
+        })
+
+    model_str1 = 'entity A {} entity B {} entity A {}'
+    model_str2 = 'entity A {} entity A {} entity B {}'
+    model_str3 = 'entity A {} entity A {} entity A {}'
+
+    # TODO test specific error message
+    for model_str in [model_str1, model_str2, model_str3]:
+        with pytest.raises(TextXSemanticError):
+            metamodel.model_from_str(model_str)
+
+
+def test_multiple_objects_inner_level():
+    """
+    Test that model grand-children uniqueness is validated.
+    """
+    metamodel = metamodel_from_str(grammar)
+    metamodel.register_obj_processors({
+        'Entity': uniq_chk_properties,
+        })
+
+    model_str1 = """
+        entity A {
+            name : string
+            age : int
+            name : float
+        }
+        """
+
+    model_str2 = """
+        entity A {
+            name : string
+            age : int
+        }
+
+        entity B {
+            name : string
+            age : int
+            age : int
+            age : int
+        }
+    """
+
+    # TODO test specific error message
+    for model_str in [model_str1, model_str2]:
+        with pytest.raises(TextXSemanticError):
+            metamodel.model_from_str(model_str)
+

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -134,7 +134,7 @@ class GlobalModelRepository(object):
 
     def load_models_using_filepattern(
             self, filename_pattern, model, glob_args, is_main_model=False,
-            encoding='utf-8'):
+            encoding='utf-8', add_to_local_models=True):
         """
         add a new model to all relevant objects
 
@@ -158,11 +158,13 @@ class GlobalModelRepository(object):
             the_metamodel = MetaModelProvider.get_metamodel(model, filename)
             loaded_models.append(
                 self.load_model(the_metamodel, filename, is_main_model,
-                                encoding=encoding))
+                                encoding=encoding,
+                                add_to_local_models=add_to_local_models))
         return loaded_models
 
     def load_model_using_search_path(
-            self, filename, model, search_path, is_main_model=False):
+            self, filename, model, search_path, is_main_model=False,
+            encoding='utf8', add_to_local_models=True):
         """
         add a new model to all relevant objects
 
@@ -185,13 +187,16 @@ class GlobalModelRepository(object):
                     MetaModelProvider.get_metamodel(model, full_filename)
                 return self.load_model(the_metamodel,
                                        full_filename,
-                                       is_main_model)
+                                       is_main_model,
+                                       encoding=encoding,
+                                       add_to_local_models=add_to_local_models)
 
         raise IOError(
             errno.ENOENT, os.strerror(errno.ENOENT), filename)
 
     def load_model(
-            self, the_metamodel, filename, is_main_model, encoding='utf-8'):
+            self, the_metamodel, filename, is_main_model, encoding='utf-8',
+            add_to_local_models=True):
         """
         load a single model
 
@@ -216,8 +221,10 @@ class GlobalModelRepository(object):
                     is_main_model=is_main_model, encoding=encoding)
                 self.all_models.filename_to_model[filename] = new_model
             # print("ADDING {}".format(filename))
-            self.local_models.filename_to_model[filename] = new_model
-        return self.local_models.filename_to_model[filename]
+            if add_to_local_models:
+                self.local_models.filename_to_model[filename] = new_model
+        assert self.all_models.has_model(filename)  # to be sure...
+        return self.all_models.filename_to_model[filename]
 
     def _add_model(self, model):
         filename = self.update_model_in_repo_based_on_filename(model)

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -5,7 +5,7 @@
 # License: MIT License
 #######################################################################
 
-from os.path import dirname, abspath
+from os.path import dirname, abspath, join
 from textx.exceptions import TextXSemanticError
 import textx.scoping as scoping
 
@@ -313,10 +313,9 @@ class ImportURI(scoping.ModelLoader):
             else:
                 # globing based i/o:
                 basedir = dirname(model._tx_filename)
-                if len(basedir) > 0:
-                    basedir += "/"
-                filename_pattern = abspath(basedir + self.importURI_converter(
-                    obj.importURI))
+                filename_pattern = abspath(
+                    join(basedir, self.importURI_converter(obj.importURI)))
+
                 obj._tx_loaded_models = \
                     model._tx_model_repository.load_models_using_filepattern(
                         filename_pattern, model=model,

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -233,8 +233,8 @@ class ImportURI(scoping.ModelLoader):
     command in an attribute _tx_loaded_models (list of models).
 
     If "importAs" is enabled AND the rule with the "importURI" attribute
-    has a "name", the loaded model is not added to the list of globally
-    visible models..
+    has a "name" not None or an empty String, the loaded model is not
+    added to the list of globally visible models..
 
     The importURI_converter is used to process the importURI attribute to
     yield a filename or a filename pattern.
@@ -282,6 +282,11 @@ class ImportURI(scoping.ModelLoader):
         visited = []
         for obj in get_children(
                 lambda x: hasattr(x, "importURI") and x not in visited, model):
+            add_to_local_models = True
+            if hasattr(obj, "name"):
+                if obj.name is not None and obj.name != "":
+                    add_to_local_models = not self.importAs
+
             visited.append(obj)
             if self.search_path is not None:
                 # search_path based i/o:
@@ -291,7 +296,7 @@ class ImportURI(scoping.ModelLoader):
                     model._tx_model_repository.load_model_using_search_path(
                         self.importURI_converter(obj.importURI), model=model,
                         search_path=my_search_path, encoding=encoding,
-                        add_to_local_models=not self.importAs)
+                        add_to_local_models=add_to_local_models)
                 obj._tx_loaded_models = [loaded_model]
 
             else:
@@ -305,7 +310,7 @@ class ImportURI(scoping.ModelLoader):
                     model._tx_model_repository.load_models_using_filepattern(
                         filename_pattern, model=model,
                         glob_args=self.glob_args, encoding=encoding,
-                        add_to_local_models=not self.importAs)
+                        add_to_local_models=add_to_local_models)
 
     def load_models(self, model, encoding='utf-8'):
         from textx.model import get_metamodel

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -377,9 +377,11 @@ class PlainNameImportURI(ImportURI):
     scope provider with ImportURI and PlainName names
     """
 
-    def __init__(self, glob_args=None, search_path=None):
+    def __init__(self, glob_args=None, search_path=None,
+                 importURI_converter=None):
         ImportURI.__init__(self, PlainName(), glob_args=glob_args,
-                           search_path=search_path)
+                           search_path=search_path,
+                           importURI_converter=importURI_converter)
 
 
 class GlobalRepo(ImportURI):

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -242,7 +242,7 @@ class ImportURI(scoping.ModelLoader):
 
     def __init__(self, scope_provider, glob_args=None, search_path=None,
                  importAs=False, importURI_converter=None,
-                 name_setter=None):
+                 importURI_to_scope_name=None):
         """
         Creates a new ImportURI Provider.
         Args:
@@ -258,11 +258,11 @@ class ImportURI(scoping.ModelLoader):
             importAs: activate importAs feature (see class documentation).
             importURI_converter: Callable to convert the importURI attribute
                 to a filename pattern (default: None).
-            name_setter: Callable to define a name based on the rule instance
-                containing the importURI attribute. With this you can set the
-                name of the importURI object to something dependent of the
-                original importURI value (caution: for an FQN based lookup,
-                this name should NOT contain dots '.').
+            importURI_to_scope_name: Callable to define a name based on the
+                rule instance containing the importURI attribute. With this
+                you can set the name of the importURI object to something
+                dependent of the original importURI value (caution: for an
+                FQN based lookup, this name should NOT contain dots '.').
 
         """
         from textx.scoping import ModelLoader
@@ -278,7 +278,7 @@ class ImportURI(scoping.ModelLoader):
             self.importURI_converter = importURI_converter
         else:
             self.importURI_converter = lambda x: x
-        self.name_setter = name_setter
+        self.importURI_to_scope_name = importURI_to_scope_name
         if glob_args:
             self.set_glob_args(glob_args)
 
@@ -291,8 +291,8 @@ class ImportURI(scoping.ModelLoader):
         for obj in get_children(
                 lambda x: hasattr(x, "importURI") and x not in visited, model):
             add_to_local_models = True
-            if self.name_setter is not None:
-                obj.name = self.name_setter(obj)
+            if self.importURI_to_scope_name is not None:
+                obj.name = self.importURI_to_scope_name(obj)
                 print("setting name to {}".format(obj.name))
             if hasattr(obj, "name"):
                 if obj.name is not None and obj.name != "":
@@ -376,12 +376,12 @@ class FQNImportURI(ImportURI):
     """
 
     def __init__(self, glob_args=None, search_path=None, importAs=False,
-                 importURI_converter=None, name_setter=None):
+                 importURI_converter=None, importURI_to_scope_name=None):
         ImportURI.__init__(self, FQN(follow_loaded_models=importAs),
                            glob_args=glob_args,
                            search_path=search_path, importAs=importAs,
                            importURI_converter=importURI_converter,
-                           name_setter=name_setter)
+                           importURI_to_scope_name=importURI_to_scope_name)
 
 
 class PlainNameImportURI(ImportURI):

--- a/textx/uniq_chk.py
+++ b/textx/uniq_chk.py
@@ -1,0 +1,44 @@
+import textx
+from textx.exceptions import TextXSemanticError
+
+# TODO does not work with imports nor fqn providers yet
+def uniq_chk(obj, attr_name):
+    """
+    Checks if 'obj' children in attribute with name 'attr_name' are unique
+    w.r.t to their name attribute. If not, throws a semantic error with source
+    info of both childrens. Can be useful for checking for multiple definitions
+
+    """
+    m = textx.get_model(obj)
+
+    def obj_src_info(obj):
+        """Returns object's line, col and filename"""
+        line, col = m._tx_parser.pos_to_linecol(obj._tx_position)
+        return line, col, m._tx_filename
+
+
+    def scan_siblings(siblings):
+        for p in siblings:
+            for q in siblings:
+                if p == q:
+                    break
+
+                if p.name == q.name:
+                    line, col, filename = obj_src_info(p)
+                    orig_line, orig_col, orig_filename = obj_src_info(q)
+
+                    msg = '\'{}\' already defined, previously seen at {}:{}:{}'\
+                            .format(p.name, orig_filename, orig_line, orig_col)
+                    raise TextXSemanticError(msg, line=line, col=col,
+                            filename=filename)
+
+    cls = obj.__class__
+    if hasattr(cls, '_tx_attrs'):
+        attr = cls._tx_attrs[attr_name]
+        if attr and attr.cont:
+            siblings = getattr(obj, attr_name)
+            scan_siblings(siblings)
+
+
+
+


### PR DESCRIPTION
I've noticed that I am writing very similar processors to check for multiple definitions of objects (entities, properties etc.) in a DSL similar to entity example.
As there is a mechanism to help with name resolution, I think it could be useful to have one to check for multiple definitions.
I have implemented a simplistic checker as an object processor. It is limited for checking non-unique children by name. Imports and scoping are not taken into account.
Please advise how this should be improved.