### PR TITLE
Strict unicode requirement for (meta)model_from_str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
    - https://github.com/igordejanovic/textX/pull/93
      - Changed attribute name for the metamodel object (from 
        "metamodel._parser" to "metamodel._parser_blueprint").
+   - https://github.com/igordejanovic/textX/pull/120
+     Unicode requirement for (meta)-model strings API parameters made strict.
+     This should prevent common errors with Python 2.x
+     See:
+     https://github.com/igordejanovic/textX/issues/105
+     https://github.com/igordejanovic/textX/pull/99
+     https://github.com/igordejanovic/textX/issues/117
+
 
 * 2018-10-06 Release 1.8.0
 

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -20,6 +20,12 @@ Parsing the input and creating the model is done by `model_from_file` and
 When parsing a model file or string a new parser is cloned for each model.
 This parser can be accessed via the model attribute `_tx_parser`.
 
+!!! warning
+
+    textX accepts unicode strings only so `metamodel_from_str` parameter should be
+    `str` for Python 3.x or `unicode` for Python 2.x. That is true for all API
+    parameters where string is accepted. The easiest way for Python 2.x is to use
+    `from __future__ import unicode_literals` at the top of the file.
 
 ## Custom classes
 

--- a/docs/model.md
+++ b/docs/model.md
@@ -24,8 +24,15 @@ A model is created from the input string using the `model_from_file` and
 
 
 !!! note
-    The model_from_file method takes an optional argument `encoding`
+    The `model_from_file` method takes an optional argument `encoding`
     to control the input encoding of the model file to be loaded.
+   
+!!! warning
+
+    textX accepts unicode strings only so `metamodel_from_str` and `model_from_str`
+    parameter should be `str` for Python 3.x or `unicode` for Python 2.x. That is
+    true for all API parameters where string is accepted. The easiest way for Python
+    2.x is to use `from __future__ import unicode_literals` at the top of the file.
 
 
 Let's take the Entity language used in [Custom

--- a/examples/expression/boolean.py
+++ b/examples/expression/boolean.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from os.path import join, dirname
 from textx import metamodel_from_str
 from textx.export import metamodel_export, model_export

--- a/examples/expression/calc.py
+++ b/examples/expression/calc.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from os.path import join, dirname
 from textx import metamodel_from_str
 from textx.export import metamodel_export, model_export

--- a/examples/expression/calc_processors.py
+++ b/examples/expression/calc_processors.py
@@ -2,6 +2,7 @@
 This is a variant of calc example using object processors for on-the-fly
 evaluation.
 """
+from __future__ import unicode_literals
 import sys
 from textx import metamodel_from_str
 

--- a/tests/functional/examples/test_hierarchical_data_structures_referencing_attributes.py
+++ b/tests/functional/examples/test_hierarchical_data_structures_referencing_attributes.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from textx import metamodel_from_str
 from pytest import raises
 import textx.exceptions

--- a/tests/functional/examples/test_modeling_float_int_variables.py
+++ b/tests/functional/examples/test_modeling_float_int_variables.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from textx import metamodel_from_str
 
 

--- a/tests/functional/regressions/test_issue72.py
+++ b/tests/functional/regressions/test_issue72.py
@@ -68,7 +68,7 @@ def default_processor(obj):
 
 
 def parse_lola(grammar, lola_str):
-    lola_str = str(lola_str)
+    lola_str = lola_str
     obj_processors = {
         "InnerObject": default_processor,
         "OuterObject": default_processor

--- a/tests/functional/regressions/test_issue78.py
+++ b/tests/functional/regressions/test_issue78.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import textx
 
 

--- a/tests/functional/regressions/test_issue97.py
+++ b/tests/functional/regressions/test_issue97.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import textx
 from pytest import raises
 

--- a/tests/functional/regressions/test_issue_53_comments.py
+++ b/tests/functional/regressions/test_issue_53_comments.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from textx import metamodel_from_str
 
 

--- a/tests/functional/regressions/test_issue_80_object_processors.py
+++ b/tests/functional/regressions/test_issue_80_object_processors.py
@@ -1,7 +1,8 @@
+from __future__ import unicode_literals
 from textx.metamodel import metamodel_from_str
 
 call_counter = 0
-grammar1 = u"""
+grammar1 = """
 foo:
     'foo' m_formula = Formula
 ;
@@ -60,7 +61,7 @@ def default_processor(obj):
 
 
 def parse_str(grammar, lola_str):
-    lola_str = str(lola_str)
+    lola_str = lola_str
     obj_processors = {
         "foo": default_processor,
         "Formula": default_processor,
@@ -78,17 +79,17 @@ def parse_str(grammar, lola_str):
 def test_issue_80_object_processors():
     global call_counter
 
-    test_str = u"foo a323 + a111"
+    test_str = "foo a323 + a111"
     call_counter = 0
     parse_str(grammar1, test_str)
     assert call_counter == 6
 
-    test_str = u"foo a323 a111"
+    test_str = "foo a323 a111"
     call_counter = 0
     parse_str(grammar2, test_str)
     assert call_counter == 6
 
-    test_str = u"foo a323 + a111"
+    test_str = "foo a323 + a111"
     call_counter = 0
     parse_str(grammar3, test_str)
     assert call_counter == 4

--- a/tests/functional/regressions/test_issue_89.py
+++ b/tests/functional/regressions/test_issue_89.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import textx
 
 

--- a/tests/functional/test_auto_init.py
+++ b/tests/functional/test_auto_init.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from __future__ import unicode_literals
 from textx import metamodel_from_str
 
 grammar = """

--- a/tests/functional/test_metaclass_reference.py
+++ b/tests/functional/test_metaclass_reference.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import pytest
 import os
 from textx import metamodel_from_str, metamodel_from_file

--- a/tests/functional/test_metamodel/test_metamodel.py
+++ b/tests/functional/test_metamodel/test_metamodel.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import pytest  # noqa
 import os
 from textx import metamodel_from_str, metamodel_from_file

--- a/tests/functional/test_metamodel/test_multi_metamodel_refs.py
+++ b/tests/functional/test_metamodel/test_multi_metamodel_refs.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import pytest  # noqa
 import os
 import os.path

--- a/tests/functional/test_metamodel_params.py
+++ b/tests/functional/test_metamodel_params.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import pytest
 from textx import metamodel_from_str
 from textx.exceptions import TextXSyntaxError

--- a/tests/functional/test_objcrossref_positions.py
+++ b/tests/functional/test_objcrossref_positions.py
@@ -1,4 +1,4 @@
-# import pytest  # noqa
+from __future__ import unicode_literals
 from textx import metamodel_from_str
 
 grammar = """

--- a/tests/functional/test_scoping/test_buildins.py
+++ b/tests/functional/test_scoping/test_buildins.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from pytest import raises
 
 import textx.exceptions

--- a/tests/functional/test_scoping/test_full_qualified_name.py
+++ b/tests/functional/test_scoping/test_full_qualified_name.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from os.path import dirname, join
 
 from pytest import raises

--- a/tests/functional/test_scoping/test_plain_name.py
+++ b/tests/functional/test_scoping/test_plain_name.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from pytest import raises
 
 import textx.exceptions

--- a/tests/functional/test_strict_unicode.py
+++ b/tests/functional/test_strict_unicode.py
@@ -1,0 +1,19 @@
+from __future__ import unicode_literals
+import pytest  # noqa
+from textx import metamodel_from_str, TextXError
+
+
+def test_that_passing_a_non_unicode_raises_exception():
+
+    # Test metamodel construction
+    with pytest.raises(TextXError,
+                       match=r'textX accepts only unicode strings.'):
+        metamodel = metamodel_from_str(42)
+
+    metamodel = metamodel_from_str('First: INT;')
+    metamodel.model_from_str('42')
+
+    # Test model constuction
+    with pytest.raises(TextXError,
+                       match=r'textX accepts only unicode strings.'):
+        metamodel.model_from_str(42)

--- a/tests/functional/test_textx_tools_support.py
+++ b/tests/functional/test_textx_tools_support.py
@@ -1,4 +1,4 @@
-# import pytest  # noqa
+from __future__ import unicode_literals
 from textx import metamodel_from_str
 
 grammar = """

--- a/tests/functional/test_unicode.py
+++ b/tests/functional/test_unicode.py
@@ -21,5 +21,11 @@ def test_unicode_grammar_from_string():
 
     """
 
+    model_str = """
+    first ♪
+    """
+
     metamodel = metamodel_from_str(grammar)
     assert metamodel
+    model = metamodel.model_from_str(model_str)
+    assert model.a == "♪"

--- a/tests/functional/test_user_class_constructor_calls.py
+++ b/tests/functional/test_user_class_constructor_calls.py
@@ -1,6 +1,7 @@
 """
 Testing user class constructor call and parent reference.
 """
+from __future__ import unicode_literals
 import pytest  # noqa
 from textx import metamodel_from_str
 

--- a/tests/functional/test_user_classes.py
+++ b/tests/functional/test_user_classes.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import pytest  # noqa
 from textx import metamodel_from_str
 

--- a/tests/functional/test_user_classes_with_properties.py
+++ b/tests/functional/test_user_classes_with_properties.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import pytest  # noqa
 from textx import metamodel_from_str
 

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -18,7 +18,7 @@ from arpeggio import StrMatch, Optional, ZeroOrMore, OneOrMore, Sequence,\
 from arpeggio.export import PMDOTExporter
 from arpeggio import RegExMatch as _
 
-from .exceptions import TextXSyntaxError, TextXSemanticError
+from .exceptions import TextXError, TextXSyntaxError, TextXSemanticError
 from .const import MULT_ONE, MULT_ZEROORMORE, MULT_ONEORMORE, \
     MULT_OPTIONAL, RULE_COMMON, RULE_MATCH, RULE_ABSTRACT, mult_lt
 
@@ -881,6 +881,9 @@ def language_from_str(language_def, metamodel):
     Returns:
         Parser for the new language.
     """
+
+    if type(language_def) is not text:
+        raise TextXError("textX accepts only unicode strings.")
 
     if metamodel.debug:
         metamodel.dprint("*** PARSING LANGUAGE DEFINITION ***")

--- a/textx/metamodel.py
+++ b/textx/metamodel.py
@@ -9,6 +9,7 @@
 from __future__ import absolute_import
 import codecs
 import os
+import sys
 from collections import OrderedDict
 from arpeggio import DebugPrinter
 from textx.six import add_metaclass
@@ -16,6 +17,12 @@ from textx.lang import language_from_str, python_type, BASE_TYPE_NAMES, ID, \
     BOOL, INT, FLOAT, STRICTFLOAT, STRING, NUMBER, BASETYPE, OBJECT
 from textx.const import MULT_ONE, MULT_ZEROORMORE, MULT_ONEORMORE, \
     RULE_MATCH, RULE_ABSTRACT
+from textx.exceptions import TextXError
+
+if sys.version < '3':
+    text = unicode  # noqa
+else:
+    text = str
 
 
 __all__ = ['metamodel_from_str', 'metamodel_from_file']
@@ -496,6 +503,10 @@ class TextXMetaModel(DebugPrinter):
                resolved. This can be useful to manage models distributed
                across files (scoping)
         """
+
+        if type(model_str) is not text:
+            raise TextXError("textX accepts only unicode strings.")
+
         model = self._parser_blueprint.clone().get_model_from_str(
             model_str, debug=debug,
             pre_ref_resolution_callback=pre_ref_resolution_callback)


### PR DESCRIPTION
Unicode requirement for (meta)-model strings API parameters made strict.
This should prevent common errors with Python 2.x

Related to #105 #99 #117
