### PR TITLE
Fixing issue from PR #128. Str. match in abstract rule.

### DIFF
--- a/tests/functional/regressions/test_issue128.py
+++ b/tests/functional/regressions/test_issue128.py
@@ -107,3 +107,38 @@ def test_abstract_alternative_string_match():
     result = evaluate(model)
 
     assert (result - 6.93805555) < 0.0001
+
+
+def test_abstract_alternative_multiple_rules():
+    grammar = r'''
+    Model: a+=A;
+    A: B | '(' C D ')';
+    B: 'B' name=ID x=INT;
+    C: 'C' name=ID;
+    D: 'D' x=INT;
+    '''
+
+    mm = metamodel_from_str(grammar)
+
+    modelstr = '''
+    B b1 1
+    B b2 2
+    ( C c1 D 11 )
+    ( C c2 D 12 )
+    '''
+
+    model = mm.model_from_str(modelstr)
+
+    assert model.a[0].name == 'b1'
+    assert model.a[0].x == 1
+    assert textx_isinstance(model.a[0], mm['A'])
+    assert textx_isinstance(model.a[0], mm['B'])
+    assert not textx_isinstance(model.a[0], mm['C'])
+    assert not textx_isinstance(model.a[0], mm['D'])
+
+    assert model.a[2].name == 'c1'
+    #assert model.a[2].x == 11                       # does not work
+    assert textx_isinstance(model.a[2], mm['A'])
+    assert not textx_isinstance(model.a[2], mm['B'])
+    assert textx_isinstance(model.a[2], mm['C'])
+    #assert textx_isinstance(model.a[2], mm['D'])  # fails

--- a/tests/functional/regressions/test_issue128.py
+++ b/tests/functional/regressions/test_issue128.py
@@ -1,0 +1,109 @@
+"""This regression tests abstract rule which have an alternative with string
+matches and a rule reference.
+
+See https://github.com/igordejanovic/textX/pull/128
+
+"""
+from __future__ import unicode_literals
+import sys
+from textx import metamodel_from_str
+from textx.scoping.tools import textx_isinstance
+
+if sys.version < '3':
+    text = unicode  # noqa
+else:
+    text = str
+
+# Global variable namespace
+namespace = {}
+
+
+def test_abstract_alternative_string_match():
+
+    grammar = r'''
+    Calc: assignments*=Assignment expression=Expression;
+    Assignment: variable=ID '=' expression=Expression ';';
+    Expression: operands=Term (operators=PlusOrMinus operands=Term)*;
+    PlusOrMinus: '+' | '-';
+    Term: operands=Factor (operators=MulOrDiv operands=Factor)*;
+    MulOrDiv: '*' | '/' ;
+    Factor: (sign=PlusOrMinus)?  op=Operand;
+    PrimitiveOperand: op_num=NUMBER | op_id=ID;
+    Operand: PrimitiveOperand | ('(' Expression ')');
+    '''
+
+    calc_mm = metamodel_from_str(grammar)
+
+    input_expr = '''
+        a = 10;
+        b = 2 * a + 17;
+        -(4-1)*a+(2+4.67)+b*5.89/(.2+7)
+    '''
+
+    model = calc_mm.model_from_str(input_expr)
+
+    def _is(x, rule):
+        return textx_isinstance(x, calc_mm[rule])
+
+    def assertIs(x, rule):
+        assert _is(x, rule), 'Unexpected object "{}" to rule "{}"'\
+                    .format(x, type(x), rule)
+
+    def evaluate(x):
+
+        if isinstance(x, float):
+            return x
+
+        elif _is(x, 'Expression'):
+            ret = evaluate(x.operands[0])
+
+            for operator, operand in zip(x.operators,
+                                         x.operands[1:]):
+                if operator == '+':
+                    ret += evaluate(operand)
+                else:
+                    ret -= evaluate(operand)
+            return ret
+
+        elif _is(x, 'Term'):
+            ret = evaluate(x.operands[0])
+
+            for operator, operand in zip(x.operators,
+                                         x.operands[1:]):
+                if operator == '*':
+                    ret *= evaluate(operand)
+                else:
+                    ret /= evaluate(operand)
+            return ret
+
+        elif _is(x, 'Factor'):
+            value = evaluate(x.op)
+            return -value if x.sign == '-' else value
+
+        elif _is(x, 'Operand'):
+            if _is(x, 'PrimitiveOperand'):
+                if x.op_num is not None:
+                    return x.op_num
+                elif x.op_id:
+                    if x.op_id in namespace:
+                        return namespace[x.op_id]
+                    else:
+                        raise Exception('Unknown variable "{}" at position {}'
+                                        .format(x.op_id, x._tx_position))
+            else:
+                assertIs(x, 'CompoundOperand')
+                return evaluate(x.expression)
+
+        elif _is(x, 'Calc'):
+            for a in x.assignments:
+                namespace[a.variable] = evaluate(a.expression)
+
+            return evaluate(x.expression)
+
+        else:
+            assert False, 'Unexpected object "{}" of type "{}"'\
+                    .format(x, type(x))
+
+    result = evaluate(model)
+
+    assert (result - 6.93805555) < 0.0001

--- a/tests/functional/regressions/test_issue128.py
+++ b/tests/functional/regressions/test_issue128.py
@@ -5,8 +5,9 @@ See https://github.com/igordejanovic/textX/pull/128
 
 """
 from __future__ import unicode_literals
+import pytest
 import sys
-from textx import metamodel_from_str
+from textx import metamodel_from_str, TextXSemanticError
 from textx.scoping.tools import textx_isinstance
 
 if sys.version < '3':
@@ -109,7 +110,15 @@ def test_abstract_alternative_string_match():
     assert (result - 6.93805555) < 0.0001
 
 
-def test_abstract_alternative_multiple_rules():
+def test_abstract_alternative_multiple_rules_raises_exception():
+    """
+    Test that multiple rules references in a single alternative of abstract
+    rule is prohibited.
+    """
+
+    # In this grammar A is an abstract rule and referencing C D from second
+    # alternative is not allowed as it would be hard to come with a coherent
+    # semantics of such a construct.
     grammar = r'''
     Model: a+=A;
     A: B | '(' C D ')';
@@ -118,27 +127,6 @@ def test_abstract_alternative_multiple_rules():
     D: 'D' x=INT;
     '''
 
-    mm = metamodel_from_str(grammar)
-
-    modelstr = '''
-    B b1 1
-    B b2 2
-    ( C c1 D 11 )
-    ( C c2 D 12 )
-    '''
-
-    model = mm.model_from_str(modelstr)
-
-    assert model.a[0].name == 'b1'
-    assert model.a[0].x == 1
-    assert textx_isinstance(model.a[0], mm['A'])
-    assert textx_isinstance(model.a[0], mm['B'])
-    assert not textx_isinstance(model.a[0], mm['C'])
-    assert not textx_isinstance(model.a[0], mm['D'])
-
-    assert model.a[2].name == 'c1'
-    #assert model.a[2].x == 11                       # does not work
-    assert textx_isinstance(model.a[2], mm['A'])
-    assert not textx_isinstance(model.a[2], mm['B'])
-    assert textx_isinstance(model.a[2], mm['C'])
-    #assert textx_isinstance(model.a[2], mm['D'])  # fails
+    with pytest.raises(TextXSemanticError,
+                       match=r'.*multiple rules.*'):
+        metamodel_from_str(grammar)

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -808,7 +808,7 @@ class TextXVisitor(PTNodeVisitor):
     def visit_str_match(self, node, children):
         try:
             to_match = children[0]
-        except:
+        except IndexError:
             to_match = ''
 
         # Support for autokwd metamodel param.
@@ -826,7 +826,7 @@ class TextXVisitor(PTNodeVisitor):
     def visit_re_match(self, node, children):
         try:
             to_match = children[0]
-        except:
+        except IndexError:
             to_match = ''
         regex = RegExMatch(to_match,
                            ignore_case=self.metamodel.ignore_case)

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -338,17 +338,31 @@ class TextXVisitor(PTNodeVisitor):
                         cls._tx_inh_by.append(rule._tx_class)
                 else:
                     # Recursivelly append all referenced classes.
-                    def _add_reffered_classes(rule, inh_by):
+                    def _add_reffered_classes(rule, inh_by, start=False):
+                        if rule.root and not start:
+                            if hasattr(rule, '_tx_class'):
+                                _determine_rule_type(rule._tx_class)
+                                if rule._tx_class._tx_type != RULE_MATCH and\
+                                        rule._tx_class not in inh_by:
+                                    inh_by.append(rule._tx_class)
+                            return 1
+                        else:
+                            rule_references = 0
+                            for r in rule.nodes:
+                                rule_references += \
+                                    _add_reffered_classes(r, inh_by)
+                            if rule_references > 1:
+                                raise TextXSemanticError(
+                                    'Referencing multiple rules from '
+                                    'a single choice of abstract rule "{}" '
+                                    'is not allowed.'.format(cls.__name__))
+                            return rule_references
+
+                    if type(rule) is OrderedChoice:
                         for r in rule.nodes:
-                            if r.root:
-                                if hasattr(r, '_tx_class'):
-                                    _determine_rule_type(r._tx_class)
-                                    if r._tx_class._tx_type != RULE_MATCH and\
-                                            r._tx_class not in inh_by:
-                                        inh_by.append(r._tx_class)
-                            else:
-                                _add_reffered_classes(r, inh_by)
-                    _add_reffered_classes(rule, cls._tx_inh_by)
+                            _add_reffered_classes(r, cls._tx_inh_by)
+                    else:
+                        _add_reffered_classes(rule, cls._tx_inh_by, start=True)
 
         resolved_classes = set()
         for cls in metamodel:

--- a/textx/model.py
+++ b/textx/model.py
@@ -353,7 +353,11 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                 # If this meta-class is product of abstract rule replace it
                 # with matched concrete meta-class down the inheritance tree.
                 # Abstract meta-class should never be instantiated.
-                return process_node(node[0])
+                if len(node) > 1:
+                    return process_node(next(n for n in node
+                                             if type(n) is not Terminal))
+                else:
+                    return process_node(node[0])
             elif mclass._tx_type == RULE_MATCH:
                 # If this is a product of match rule handle it as a RHS
                 # of assignment and return converted python type.


### PR DESCRIPTION
Fixes issue discovered in PR #128.

While I was there two bare `except` were fixed also.