### PR TITLE
#157: make textx_isinstance from textx.scoping.tools available

### DIFF
--- a/docs/multimetamodel.md
+++ b/docs/multimetamodel.md
@@ -21,7 +21,7 @@ meta models can also reference elements of models created with the original
 meta model. Although the meta classes corresponding to inherited rules are 
 redefined by the extending meta model, scope providers match the object 
 types correctly. This is implemented by comparing the types by their name 
-(see textx.scoping.tool.textx_isinstance). Simple examples: see 
+(see textx.textx_isinstance). Simple examples: see 
 [tests/functional/test_scoping/test_metamodel_provider*.py](https://github.com/textX/textX/tree/master/tests/functional/test_scoping).
 
 

--- a/examples/expression/calc_isinstance.py
+++ b/examples/expression/calc_isinstance.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 import sys
 from os.path import join, dirname
 from textx import metamodel_from_str
-from textx.scoping.tools import textx_isinstance
+from textx import textx_isinstance
 from textx.export import metamodel_export, model_export
 
 if sys.version < '3':

--- a/tests/functional/regressions/test_issue103_python_like_import.py
+++ b/tests/functional/regressions/test_issue103_python_like_import.py
@@ -82,7 +82,7 @@ def test_issue103_imported_namedspaces():
         return import_obj.importURI.split('.')[0]
 
     def custom_scope_redirection(obj):
-        from textx.scoping.tools import textx_isinstance
+        from textx import textx_isinstance
         if textx_isinstance(obj, mm["PackageRef"]):
             if obj.ref is None:
                 from textx.scoping import Postponed

--- a/tests/functional/regressions/test_issue128.py
+++ b/tests/functional/regressions/test_issue128.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 import pytest
 import sys
 from textx import metamodel_from_str, TextXSemanticError
-from textx.scoping.tools import textx_isinstance
+from textx import textx_isinstance
 
 if sys.version < '3':
     text = unicode  # noqa

--- a/tests/functional/test_scoping/test_metamodel_provider3.py
+++ b/tests/functional/test_scoping/test_metamodel_provider3.py
@@ -80,7 +80,7 @@ def test_metamodel_provider_advanced_test3_global():
     assert a_mm["Cls"]._tx_fqn == b_mm["Cls"]._tx_fqn
 
     # more checks
-    from textx.scoping.tools import textx_isinstance
+    from textx import textx_isinstance
     for a in lst:
         assert textx_isinstance(a, a_mm["Obj"])
         assert textx_isinstance(a, b_mm["Obj"])

--- a/tests/functional/test_scoping/test_scoping_tools.py
+++ b/tests/functional/test_scoping/test_scoping_tools.py
@@ -6,7 +6,7 @@ from textx import metamodel_from_file, metamodel_from_str
 from textx.scoping.tools import get_referenced_object, \
     get_list_of_concatenated_objects
 from textx.scoping.tools import get_unique_named_object
-from textx.scoping.tools import textx_isinstance
+from textx import textx_isinstance
 from textx import get_children_of_type
 
 

--- a/textx/__init__.py
+++ b/textx/__init__.py
@@ -5,5 +5,6 @@ from textx.model import get_children_of_type, get_parent_of_type, \
 from textx.exceptions import TextXError, TextXSyntaxError, \
     TextXSemanticError
 from textx.langapi import get_language, iter_languages
+from textx.scoping.tools import textx_isinstance
 
 __version__ = "1.8.0"

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -87,7 +87,7 @@ class PlainName(object):
 
         if self.multi_metamodel_support:
             from textx import get_model, get_children
-            from textx.scoping.tools import textx_isinstance
+            from textx import textx_isinstance
             result_lst = get_children(
                 lambda x:
                 hasattr(x, "name") and x.name == obj_ref.obj_name
@@ -199,7 +199,7 @@ class FQN(object):
                 else:
                     return None
 
-            from textx.scoping.tools import textx_isinstance
+            from textx import textx_isinstance
             if textx_isinstance(obj, cls):
                 return p
             else:


### PR DESCRIPTION
(as described in #157)

closes #157 