### PR TITLE
Feature/language registration meta model provider replacement

### DIFF
--- a/tests/functional/regressions/test_issue140.py
+++ b/tests/functional/regressions/test_issue140.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
 import os
 import os.path
-from textx import metamodel_from_file
+from textx import metamodel_from_file, LanguageDesc,\
+    register_language, clear_language_registrations
 import textx.scoping.providers as scoping_providers
 import textx.scoping as scoping
 
@@ -36,9 +37,21 @@ def test_multi_metamodel_obj_proc():
     mm_A.register_obj_processors({"C1": proc})
     mm_B.register_obj_processors({"C1": proc})
 
-    scoping.MetaModelProvider.clear()
-    scoping.MetaModelProvider.add_metamodel("*.a", mm_A)
-    scoping.MetaModelProvider.add_metamodel("*.b", mm_B)
+    a_dsl = LanguageDesc(
+        name='a-dsl',
+        pattern='*.a',
+        description='Test Lang A',
+        metamodel=mm_A)
+
+    b_dsl = LanguageDesc(
+        name='b-dsl',
+        pattern='*.b',
+        description='Test Lang B',
+        metamodel=mm_B)
+
+    clear_language_registrations()
+    register_language(a_dsl)
+    register_language(b_dsl)
 
     mm_B.model_from_file(os.path.join(
         os.path.dirname(__file__),

--- a/tests/functional/regressions/test_issue140.py
+++ b/tests/functional/regressions/test_issue140.py
@@ -37,21 +37,17 @@ def test_multi_metamodel_obj_proc():
     mm_A.register_obj_processors({"C1": proc})
     mm_B.register_obj_processors({"C1": proc})
 
-    a_dsl = LanguageDesc(
-        name='a-dsl',
+    clear_language_registrations()
+    register_language(
+        'a-dsl',
         pattern='*.a',
         description='Test Lang A',
         metamodel=mm_A)
-
-    b_dsl = LanguageDesc(
-        name='b-dsl',
+    register_language(
+        'b-dsl',
         pattern='*.b',
         description='Test Lang B',
         metamodel=mm_B)
-
-    clear_language_registrations()
-    register_language(a_dsl)
-    register_language(b_dsl)
 
     mm_B.model_from_file(os.path.join(
         os.path.dirname(__file__),

--- a/tests/functional/test_metamodel/test_multi_metamodel_refs.py
+++ b/tests/functional/test_metamodel/test_multi_metamodel_refs.py
@@ -55,16 +55,16 @@ def register_languages():
             {"*.*": scoping_providers.FQNImportURI()})
         return mm_B
 
-    register_language(LanguageDesc(name='A',
-                                   pattern="*.a",
-                                   metamodel=get_A_mm))
-    register_language(LanguageDesc(name='B',
-                                   pattern="*.b",
-                                   metamodel=get_B_mm))
+    register_language('A',
+                      pattern="*.a",
+                      metamodel=get_A_mm)
+    register_language('B',
+                      pattern="*.b",
+                      metamodel=get_B_mm)
 
-    register_language(LanguageDesc(name='BwithImport',
-                                   pattern="*.b",
-                                   metamodel=get_BwithImport_mm))
+    register_language('BwithImport',
+                      pattern="*.b",
+                      metamodel=get_BwithImport_mm)
 
     return global_repo_provider
 
@@ -189,8 +189,8 @@ class LibTypes:
 
             return mm
 
-        register_language(LanguageDesc(name='types', pattern='*.type',
-                                       metamodel=get_metamodel))
+        register_language('types', pattern='*.type',
+                          metamodel=get_metamodel)
 
 
 class LibData:
@@ -234,9 +234,9 @@ class LibData:
 
             return mm
 
-        register_language(LanguageDesc(name='data',
-                                       pattern='*.data',
-                                       metamodel=get_metamodel))
+        register_language('data',
+                          pattern='*.data',
+                          metamodel=get_metamodel)
 
 
 class LibFlow:
@@ -289,9 +289,9 @@ class LibFlow:
 
             return mm
 
-        register_language(LanguageDesc(name='flow',
-                                       pattern='*.flow',
-                                       metamodel=get_metamodel))
+        register_language('flow',
+                          pattern='*.flow',
+                          metamodel=get_metamodel)
 
 
 def test_multi_metamodel_types_data_flow1():

--- a/tests/functional/test_scoping/test_exception_from_included_model.py
+++ b/tests/functional/test_scoping/test_exception_from_included_model.py
@@ -52,28 +52,22 @@ def test_exception_from_included_model():
         import_lookup_provider, join(this_folder,
                                      "metamodel_provider3", "C.tx"))
 
-    a_dsl = LanguageDesc(
-        name='a-dsl',
+    clear_language_registrations()
+    register_language(
+        'a-dsl',
         pattern='*.a',
         description='Test Lang A',
         metamodel=a_mm)
-
-    b_dsl = LanguageDesc(
-        name='b-dsl',
+    register_language(
+        'b-dsl',
         pattern='*.b',
         description='Test Lang B',
         metamodel=b_mm)
-
-    c_dsl = LanguageDesc(
-        name='c-dsl',
+    register_language(
+        'c-dsl',
         pattern='*.c',
         description='Test Lang C',
         metamodel=c_mm)
-
-    clear_language_registrations()
-    register_language(a_dsl)
-    register_language(b_dsl)
-    register_language(c_dsl)
 
     #################################
     # MODEL PARSING / TEST

--- a/tests/functional/test_scoping/test_exception_from_included_model.py
+++ b/tests/functional/test_scoping/test_exception_from_included_model.py
@@ -6,7 +6,8 @@ from pytest import raises
 
 import textx.scoping as scoping
 import textx.scoping.providers as scoping_providers
-from textx import metamodel_from_file
+from textx import metamodel_from_file, LanguageDesc,\
+    register_language, clear_language_registrations
 
 
 def test_exception_from_included_model():
@@ -51,6 +52,29 @@ def test_exception_from_included_model():
     c_mm = get_meta_model(
         import_lookup_provider, join(this_folder,
                                      "metamodel_provider3", "C.tx"))
+
+    a_dsl = LanguageDesc(
+        name='a-dsl',
+        pattern='*.a',
+        description='Test Lang A',
+        metamodel=a_mm)
+
+    b_dsl = LanguageDesc(
+        name='b-dsl',
+        pattern='*.b',
+        description='Test Lang B',
+        metamodel=b_mm)
+
+    c_dsl = LanguageDesc(
+        name='c-dsl',
+        pattern='*.c',
+        description='Test Lang C',
+        metamodel=c_mm)
+
+    clear_language_registrations()
+    register_language(a_dsl)
+    register_language(b_dsl)
+    register_language(c_dsl)
 
     scoping.MetaModelProvider.clear()
     scoping.MetaModelProvider.add_metamodel("*.a", a_mm)

--- a/tests/functional/test_scoping/test_exception_from_included_model.py
+++ b/tests/functional/test_scoping/test_exception_from_included_model.py
@@ -4,7 +4,6 @@ from os.path import dirname, abspath, join
 
 from pytest import raises
 
-import textx.scoping as scoping
 import textx.scoping.providers as scoping_providers
 from textx import metamodel_from_file, LanguageDesc,\
     register_language, clear_language_registrations
@@ -76,10 +75,28 @@ def test_exception_from_included_model():
     register_language(b_dsl)
     register_language(c_dsl)
 
-    scoping.MetaModelProvider.clear()
-    scoping.MetaModelProvider.add_metamodel("*.a", a_mm)
-    scoping.MetaModelProvider.add_metamodel("*.b", b_mm)
-    scoping.MetaModelProvider.add_metamodel("*.c", c_mm)
+    a_dsl = LanguageDesc(
+        name='a-dsl',
+        pattern='*.a',
+        description='Test Lang A',
+        metamodel=a_mm)
+
+    b_dsl = LanguageDesc(
+        name='b-dsl',
+        pattern='*.b',
+        description='Test Lang B',
+        metamodel=b_mm)
+
+    c_dsl = LanguageDesc(
+        name='c-dsl',
+        pattern='*.c',
+        description='Test Lang C',
+        metamodel=c_mm)
+
+    clear_language_registrations()
+    register_language(a_dsl)
+    register_language(b_dsl)
+    register_language(c_dsl)
 
     #################################
     # MODEL PARSING / TEST
@@ -95,4 +112,4 @@ def test_exception_from_included_model():
     #################################
     # END
     #################################
-    scoping.MetaModelProvider.clear()
+    clear_language_registrations()

--- a/tests/functional/test_scoping/test_exception_from_included_model.py
+++ b/tests/functional/test_scoping/test_exception_from_included_model.py
@@ -75,29 +75,6 @@ def test_exception_from_included_model():
     register_language(b_dsl)
     register_language(c_dsl)
 
-    a_dsl = LanguageDesc(
-        name='a-dsl',
-        pattern='*.a',
-        description='Test Lang A',
-        metamodel=a_mm)
-
-    b_dsl = LanguageDesc(
-        name='b-dsl',
-        pattern='*.b',
-        description='Test Lang B',
-        metamodel=b_mm)
-
-    c_dsl = LanguageDesc(
-        name='c-dsl',
-        pattern='*.c',
-        description='Test Lang C',
-        metamodel=c_mm)
-
-    clear_language_registrations()
-    register_language(a_dsl)
-    register_language(b_dsl)
-    register_language(c_dsl)
-
     #################################
     # MODEL PARSING / TEST
     #################################

--- a/tests/functional/test_scoping/test_metamodel_provider.py
+++ b/tests/functional/test_scoping/test_metamodel_provider.py
@@ -4,10 +4,11 @@ from os.path import dirname, abspath, join
 
 from pytest import raises
 
-import textx.scoping as scoping
 import textx.scoping.providers as scoping_providers
 from textx import metamodel_from_file
 from textx.scoping.tools import get_unique_named_object_in_all_models
+from textx import LanguageDesc, \
+    register_language, clear_language_registrations
 
 
 def test_metamodel_provider_basic_test():
@@ -17,6 +18,10 @@ def test_metamodel_provider_basic_test():
     are used twice. It is checked that the correct metamodel
     is used to load a model (by loading a model constellation using
     two metamodels).
+
+    Note: the MetaModelProvider is obsolete. This test is fixed
+    in terms of how to handle the filename --> metamodel resolution
+    in textx >= 2.x
     """
     #################################
     # META MODEL DEF
@@ -39,10 +44,26 @@ def test_metamodel_provider_basic_test():
         "*.*": scoping_providers.FQNImportURI(),
     })
 
-    scoping.MetaModelProvider.add_metamodel("*.components", mm_components)
-    scoping.MetaModelProvider.add_metamodel("*.users", mm_users)
-    with raises(Exception, match=r'.*pattern.*already registered.*'):
-        scoping.MetaModelProvider.add_metamodel("*.users", mm_users)
+    clear_language_registrations()
+    register_language(LanguageDesc(
+        name='components-dsl',
+        pattern='*.components',
+        description='demo',
+        metamodel=mm_components  # or a factory
+    ))
+    register_language(LanguageDesc(
+        name='users-dsl',
+        pattern='*.users',
+        description='demo',
+        metamodel=mm_users  # or a factory
+    ))
+    with raises(Exception, match=r'.*already registered.*'):
+        register_language(LanguageDesc(
+            name='users-dsl',
+            pattern='*.users',
+            description='demo',
+            metamodel=mm_users  # or a factory
+        ))
 
     #################################
     # MODEL PARSING

--- a/tests/functional/test_scoping/test_metamodel_provider.py
+++ b/tests/functional/test_scoping/test_metamodel_provider.py
@@ -45,25 +45,25 @@ def test_metamodel_provider_basic_test():
     })
 
     clear_language_registrations()
-    register_language(LanguageDesc(
-        name='components-dsl',
+    register_language(
+        'components-dsl',
         pattern='*.components',
         description='demo',
         metamodel=mm_components  # or a factory
-    ))
-    register_language(LanguageDesc(
-        name='users-dsl',
+    )
+    register_language(
+        'users-dsl',
         pattern='*.users',
         description='demo',
         metamodel=mm_users  # or a factory
-    ))
+    )
     with raises(Exception, match=r'.*already registered.*'):
-        register_language(LanguageDesc(
-            name='users-dsl',
+        register_language(
+            'users-dsl',
             pattern='*.users',
             description='demo',
             metamodel=mm_users  # or a factory
-        ))
+        )
 
     #################################
     # MODEL PARSING

--- a/tests/functional/test_scoping/test_metamodel_provider2.py
+++ b/tests/functional/test_scoping/test_metamodel_provider2.py
@@ -45,18 +45,18 @@ def test_metamodel_provider_advanced_test():
         global_repo, join(this_folder, "metamodel_provider2", "Recipe.tx"))
 
     clear_language_registrations()
-    register_language(LanguageDesc(
-        name='recipe-dsl',
+    register_language(
+        'recipe-dsl',
         pattern='*.recipe',
         description='demo',
         metamodel=r_mm  # or a factory
-    ))
-    register_language(LanguageDesc(
-        name='ingredient-dsl',
+    )
+    register_language(
+        'ingredient-dsl',
         pattern='*.ingredient',
         description='demo',
         metamodel=i_mm  # or a factory
-    ))
+    )
 
     #################################
     # MODEL PARSING

--- a/tests/functional/test_scoping/test_metamodel_provider2.py
+++ b/tests/functional/test_scoping/test_metamodel_provider2.py
@@ -2,9 +2,10 @@ from __future__ import unicode_literals
 
 from os.path import dirname, abspath, join
 
-import textx.scoping as scoping
 import textx.scoping.providers as scoping_providers
 from textx import metamodel_from_file, get_children_of_type
+from textx import LanguageDesc, \
+    register_language, clear_language_registrations
 
 
 def test_metamodel_provider_advanced_test():
@@ -43,8 +44,19 @@ def test_metamodel_provider_advanced_test():
     r_mm = get_meta_model(
         global_repo, join(this_folder, "metamodel_provider2", "Recipe.tx"))
 
-    scoping.MetaModelProvider.add_metamodel("*.recipe", r_mm)
-    scoping.MetaModelProvider.add_metamodel("*.ingredient", i_mm)
+    clear_language_registrations()
+    register_language(LanguageDesc(
+        name='recipe-dsl',
+        pattern='*.recipe',
+        description='demo',
+        metamodel=r_mm  # or a factory
+    ))
+    register_language(LanguageDesc(
+        name='ingredient-dsl',
+        pattern='*.ingredient',
+        description='demo',
+        metamodel=i_mm  # or a factory
+    ))
 
     #################################
     # MODEL PARSING

--- a/tests/functional/test_scoping/test_metamodel_provider3.py
+++ b/tests/functional/test_scoping/test_metamodel_provider3.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from os.path import dirname, abspath, join
 
-import textx.scoping as scoping
 import textx.scoping.providers as scoping_providers
 from textx import get_children_of_type
 from textx import metamodel_from_file, LanguageDesc,\
@@ -109,7 +108,7 @@ def test_metamodel_provider_advanced_test3_global():
     #################################
     # END
     #################################
-    scoping.MetaModelProvider.clear()
+    clear_language_registrations()
 
 
 def test_metamodel_provider_advanced_test3_import():
@@ -146,10 +145,28 @@ def test_metamodel_provider_advanced_test3_import():
         import_lookup_provider, join(this_folder,
                                      "metamodel_provider3", "C.tx"))
 
-    scoping.MetaModelProvider.clear()
-    scoping.MetaModelProvider.add_metamodel("*.a", a_mm)
-    scoping.MetaModelProvider.add_metamodel("*.b", b_mm)
-    scoping.MetaModelProvider.add_metamodel("*.c", c_mm)
+    a_dsl = LanguageDesc(
+        name='a-dsl',
+        pattern='*.a',
+        description='Test Lang A',
+        metamodel=a_mm)
+
+    b_dsl = LanguageDesc(
+        name='b-dsl',
+        pattern='*.b',
+        description='Test Lang B',
+        metamodel=b_mm)
+
+    c_dsl = LanguageDesc(
+        name='c-dsl',
+        pattern='*.c',
+        description='Test Lang C',
+        metamodel=c_mm)
+
+    clear_language_registrations()
+    register_language(a_dsl)
+    register_language(b_dsl)
+    register_language(c_dsl)
 
     #################################
     # MODEL PARSING
@@ -180,7 +197,7 @@ def test_metamodel_provider_advanced_test3_import():
     #################################
     # END
     #################################
-    scoping.MetaModelProvider.clear()
+    clear_language_registrations()
 
 
 def test_metamodel_provider_advanced_test3_inheritance():
@@ -276,7 +293,7 @@ def test_metamodel_provider_advanced_test3_inheritance():
     #################################
     # END
     #################################
-    scoping.MetaModelProvider.clear()
+    clear_language_registrations()
 
 
 def test_metamodel_provider_advanced_test3_inheritance2():
@@ -312,10 +329,28 @@ def test_metamodel_provider_advanced_test3_inheritance2():
         import_lookup_provider, join(this_folder,
                                      "metamodel_provider3", "C.tx"))
 
-    scoping.MetaModelProvider.clear()
-    scoping.MetaModelProvider.add_metamodel("*.a", a_mm)
-    scoping.MetaModelProvider.add_metamodel("*.b", b_mm)
-    scoping.MetaModelProvider.add_metamodel("*.c", c_mm)
+    a_dsl = LanguageDesc(
+        name='a-dsl',
+        pattern='*.a',
+        description='Test Lang A',
+        metamodel=a_mm)
+
+    b_dsl = LanguageDesc(
+        name='b-dsl',
+        pattern='*.b',
+        description='Test Lang B',
+        metamodel=b_mm)
+
+    c_dsl = LanguageDesc(
+        name='c-dsl',
+        pattern='*.c',
+        description='Test Lang C',
+        metamodel=c_mm)
+
+    clear_language_registrations()
+    register_language(a_dsl)
+    register_language(b_dsl)
+    register_language(c_dsl)
 
     #################################
     # MODEL PARSING
@@ -354,7 +389,7 @@ def test_metamodel_provider_advanced_test3_inheritance2():
     #################################
     # END
     #################################
-    scoping.MetaModelProvider.clear()
+    clear_language_registrations()
 
 
 def test_metamodel_provider_advanced_test3_diamond():
@@ -391,10 +426,28 @@ def test_metamodel_provider_advanced_test3_diamond():
         import_lookup_provider, join(this_folder,
                                      "metamodel_provider3", "C.tx"))
 
-    scoping.MetaModelProvider.clear()
-    scoping.MetaModelProvider.add_metamodel("*.a", a_mm)
-    scoping.MetaModelProvider.add_metamodel("*.b", b_mm)
-    scoping.MetaModelProvider.add_metamodel("*.c", c_mm)
+    a_dsl = LanguageDesc(
+        name='a-dsl',
+        pattern='*.a',
+        description='Test Lang A',
+        metamodel=a_mm)
+
+    b_dsl = LanguageDesc(
+        name='b-dsl',
+        pattern='*.b',
+        description='Test Lang B',
+        metamodel=b_mm)
+
+    c_dsl = LanguageDesc(
+        name='c-dsl',
+        pattern='*.c',
+        description='Test Lang C',
+        metamodel=c_mm)
+
+    clear_language_registrations()
+    register_language(a_dsl)
+    register_language(b_dsl)
+    register_language(c_dsl)
 
     #################################
     # MODEL PARSING
@@ -433,4 +486,4 @@ def test_metamodel_provider_advanced_test3_diamond():
     #################################
     # END
     #################################
-    scoping.MetaModelProvider.clear()
+    clear_language_registrations()

--- a/tests/functional/test_scoping/test_metamodel_provider3.py
+++ b/tests/functional/test_scoping/test_metamodel_provider3.py
@@ -48,28 +48,22 @@ def test_metamodel_provider_advanced_test3_global():
         global_repo_provider, join(this_folder,
                                    "metamodel_provider3", "C.tx"))
 
-    a_dsl = LanguageDesc(
-        name='a-dsl',
+    clear_language_registrations()
+    register_language(
+        'a-dsl',
         pattern='*.a',
         description='Test Lang A',
         metamodel=a_mm)
-
-    b_dsl = LanguageDesc(
-        name='b-dsl',
+    register_language(
+        'b-dsl',
         pattern='*.b',
         description='Test Lang B',
         metamodel=b_mm)
-
-    c_dsl = LanguageDesc(
-        name='c-dsl',
+    register_language(
+        'c-dsl',
         pattern='*.c',
         description='Test Lang C',
         metamodel=c_mm)
-
-    clear_language_registrations()
-    register_language(a_dsl)
-    register_language(b_dsl)
-    register_language(c_dsl)
 
     #################################
     # MODEL PARSING
@@ -145,28 +139,22 @@ def test_metamodel_provider_advanced_test3_import():
         import_lookup_provider, join(this_folder,
                                      "metamodel_provider3", "C.tx"))
 
-    a_dsl = LanguageDesc(
-        name='a-dsl',
+    clear_language_registrations()
+    register_language(
+        'a-dsl',
         pattern='*.a',
         description='Test Lang A',
         metamodel=a_mm)
-
-    b_dsl = LanguageDesc(
-        name='b-dsl',
+    register_language(
+        'b-dsl',
         pattern='*.b',
         description='Test Lang B',
         metamodel=b_mm)
-
-    c_dsl = LanguageDesc(
-        name='c-dsl',
+    register_language(
+        'c-dsl',
         pattern='*.c',
         description='Test Lang C',
         metamodel=c_mm)
-
-    clear_language_registrations()
-    register_language(a_dsl)
-    register_language(b_dsl)
-    register_language(c_dsl)
 
     #################################
     # MODEL PARSING
@@ -240,28 +228,22 @@ def test_metamodel_provider_advanced_test3_inheritance():
         import_lookup_provider, join(this_folder,
                                      "metamodel_provider3", "C.tx"))
 
-    a_dsl = LanguageDesc(
-        name='a-dsl',
+    clear_language_registrations()
+    register_language(
+        'a-dsl',
         pattern='*.a',
         description='Test Lang A',
         metamodel=a_mm)
-
-    b_dsl = LanguageDesc(
-        name='b-dsl',
+    register_language(
+        'b-dsl',
         pattern='*.b',
         description='Test Lang B',
         metamodel=b_mm)
-
-    c_dsl = LanguageDesc(
-        name='c-dsl',
+    register_language(
+        'c-dsl',
         pattern='*.c',
         description='Test Lang C',
         metamodel=c_mm)
-
-    clear_language_registrations()
-    register_language(a_dsl)
-    register_language(b_dsl)
-    register_language(c_dsl)
 
     #################################
     # MODEL PARSING
@@ -329,28 +311,22 @@ def test_metamodel_provider_advanced_test3_inheritance2():
         import_lookup_provider, join(this_folder,
                                      "metamodel_provider3", "C.tx"))
 
-    a_dsl = LanguageDesc(
-        name='a-dsl',
+    clear_language_registrations()
+    register_language(
+        'a-dsl',
         pattern='*.a',
         description='Test Lang A',
         metamodel=a_mm)
-
-    b_dsl = LanguageDesc(
-        name='b-dsl',
+    register_language(
+        'b-dsl',
         pattern='*.b',
         description='Test Lang B',
         metamodel=b_mm)
-
-    c_dsl = LanguageDesc(
-        name='c-dsl',
+    register_language(
+        'c-dsl',
         pattern='*.c',
         description='Test Lang C',
         metamodel=c_mm)
-
-    clear_language_registrations()
-    register_language(a_dsl)
-    register_language(b_dsl)
-    register_language(c_dsl)
 
     #################################
     # MODEL PARSING
@@ -426,28 +402,22 @@ def test_metamodel_provider_advanced_test3_diamond():
         import_lookup_provider, join(this_folder,
                                      "metamodel_provider3", "C.tx"))
 
-    a_dsl = LanguageDesc(
-        name='a-dsl',
+    clear_language_registrations()
+    register_language(
+        'a-dsl',
         pattern='*.a',
         description='Test Lang A',
         metamodel=a_mm)
-
-    b_dsl = LanguageDesc(
-        name='b-dsl',
+    register_language(
+        'b-dsl',
         pattern='*.b',
         description='Test Lang B',
         metamodel=b_mm)
-
-    c_dsl = LanguageDesc(
-        name='c-dsl',
+    register_language(
+        'c-dsl',
         pattern='*.c',
         description='Test Lang C',
         metamodel=c_mm)
-
-    clear_language_registrations()
-    register_language(a_dsl)
-    register_language(b_dsl)
-    register_language(c_dsl)
 
     #################################
     # MODEL PARSING

--- a/tests/functional/test_scoping/test_metamodel_provider3.py
+++ b/tests/functional/test_scoping/test_metamodel_provider3.py
@@ -4,7 +4,9 @@ from os.path import dirname, abspath, join
 
 import textx.scoping as scoping
 import textx.scoping.providers as scoping_providers
-from textx import metamodel_from_file, get_children_of_type
+from textx import get_children_of_type
+from textx import metamodel_from_file, LanguageDesc,\
+    register_language, clear_language_registrations
 
 
 def test_metamodel_provider_advanced_test3_global():
@@ -47,10 +49,28 @@ def test_metamodel_provider_advanced_test3_global():
         global_repo_provider, join(this_folder,
                                    "metamodel_provider3", "C.tx"))
 
-    scoping.MetaModelProvider.clear()
-    scoping.MetaModelProvider.add_metamodel("*.a", a_mm)
-    scoping.MetaModelProvider.add_metamodel("*.b", b_mm)
-    scoping.MetaModelProvider.add_metamodel("*.c", c_mm)
+    a_dsl = LanguageDesc(
+        name='a-dsl',
+        pattern='*.a',
+        description='Test Lang A',
+        metamodel=a_mm)
+
+    b_dsl = LanguageDesc(
+        name='b-dsl',
+        pattern='*.b',
+        description='Test Lang B',
+        metamodel=b_mm)
+
+    c_dsl = LanguageDesc(
+        name='c-dsl',
+        pattern='*.c',
+        description='Test Lang C',
+        metamodel=c_mm)
+
+    clear_language_registrations()
+    register_language(a_dsl)
+    register_language(b_dsl)
+    register_language(c_dsl)
 
     #################################
     # MODEL PARSING
@@ -203,10 +223,28 @@ def test_metamodel_provider_advanced_test3_inheritance():
         import_lookup_provider, join(this_folder,
                                      "metamodel_provider3", "C.tx"))
 
-    scoping.MetaModelProvider.clear()
-    scoping.MetaModelProvider.add_metamodel("*.a", a_mm)
-    scoping.MetaModelProvider.add_metamodel("*.b", b_mm)
-    scoping.MetaModelProvider.add_metamodel("*.c", c_mm)
+    a_dsl = LanguageDesc(
+        name='a-dsl',
+        pattern='*.a',
+        description='Test Lang A',
+        metamodel=a_mm)
+
+    b_dsl = LanguageDesc(
+        name='b-dsl',
+        pattern='*.b',
+        description='Test Lang B',
+        metamodel=b_mm)
+
+    c_dsl = LanguageDesc(
+        name='c-dsl',
+        pattern='*.c',
+        description='Test Lang C',
+        metamodel=c_mm)
+
+    clear_language_registrations()
+    register_language(a_dsl)
+    register_language(b_dsl)
+    register_language(c_dsl)
 
     #################################
     # MODEL PARSING

--- a/tests/functional/test_scoping/test_metamodel_provider_utf_16_le.py
+++ b/tests/functional/test_scoping/test_metamodel_provider_utf_16_le.py
@@ -36,18 +36,18 @@ def test_metamodel_provider_utf_16_le_basic_test():
     })
 
     clear_language_registrations()
-    register_language(LanguageDesc(
-        name='components-dsl',
+    register_language(
+        'components-dsl',
         pattern='*.components',
         description='demo',
         metamodel=mm_components  # or a factory
-    ))
-    register_language(LanguageDesc(
-        name='users-dsl',
+    )
+    register_language(
+        'users-dsl',
         pattern='*.users',
         description='demo',
         metamodel=mm_users  # or a factory
-    ))
+    )
 
     #################################
     # MODEL PARSING

--- a/tests/functional/test_scoping/test_metamodel_provider_utf_16_le.py
+++ b/tests/functional/test_scoping/test_metamodel_provider_utf_16_le.py
@@ -2,10 +2,10 @@ from __future__ import unicode_literals
 
 from os.path import dirname, abspath, join
 
-import textx.scoping as scoping
 import textx.scoping.providers as scoping_providers
-from textx import metamodel_from_file
 from textx.scoping.tools import get_unique_named_object_in_all_models
+from textx import metamodel_from_file, LanguageDesc,\
+    register_language, clear_language_registrations
 
 
 def test_metamodel_provider_utf_16_le_basic_test():
@@ -35,8 +35,19 @@ def test_metamodel_provider_utf_16_le_basic_test():
         "*.*": scoping_providers.FQNImportURI(),
     })
 
-    scoping.MetaModelProvider.add_metamodel("*.components", mm_components)
-    scoping.MetaModelProvider.add_metamodel("*.users", mm_users)
+    clear_language_registrations()
+    register_language(LanguageDesc(
+        name='components-dsl',
+        pattern='*.components',
+        description='demo',
+        metamodel=mm_components  # or a factory
+    ))
+    register_language(LanguageDesc(
+        name='users-dsl',
+        pattern='*.users',
+        description='demo',
+        metamodel=mm_users  # or a factory
+    ))
 
     #################################
     # MODEL PARSING

--- a/tests/functional/test_scoping/test_model_export.py
+++ b/tests/functional/test_scoping/test_model_export.py
@@ -4,9 +4,9 @@ import io
 from os.path import dirname, abspath, join, sep
 
 import textx.export as export
-import textx.scoping as scoping
 import textx.scoping.providers as scoping_providers
-from textx import metamodel_from_file
+from textx import metamodel_from_file, LanguageDesc,\
+    register_language, clear_language_registrations
 
 
 def test_model_export():
@@ -45,10 +45,28 @@ def test_model_export():
         import_lookup_provider, join(this_folder,
                                      "metamodel_provider3", "C.tx"))
 
-    scoping.MetaModelProvider.clear()
-    scoping.MetaModelProvider.add_metamodel("*.a", a_mm)
-    scoping.MetaModelProvider.add_metamodel("*.b", b_mm)
-    scoping.MetaModelProvider.add_metamodel("*.c", c_mm)
+    a_dsl = LanguageDesc(
+        name='a-dsl',
+        pattern='*.a',
+        description='Test Lang A',
+        metamodel=a_mm)
+
+    b_dsl = LanguageDesc(
+        name='b-dsl',
+        pattern='*.b',
+        description='Test Lang B',
+        metamodel=b_mm)
+
+    c_dsl = LanguageDesc(
+        name='c-dsl',
+        pattern='*.c',
+        description='Test Lang C',
+        metamodel=c_mm)
+
+    clear_language_registrations()
+    register_language(a_dsl)
+    register_language(b_dsl)
+    register_language(c_dsl)
 
     #################################
     # MODEL PARSING

--- a/tests/functional/test_scoping/test_model_export.py
+++ b/tests/functional/test_scoping/test_model_export.py
@@ -45,28 +45,22 @@ def test_model_export():
         import_lookup_provider, join(this_folder,
                                      "metamodel_provider3", "C.tx"))
 
-    a_dsl = LanguageDesc(
-        name='a-dsl',
+    clear_language_registrations()
+    register_language(
+        'a-dsl',
         pattern='*.a',
         description='Test Lang A',
         metamodel=a_mm)
-
-    b_dsl = LanguageDesc(
-        name='b-dsl',
+    register_language(
+        'b-dsl',
         pattern='*.b',
         description='Test Lang B',
         metamodel=b_mm)
-
-    c_dsl = LanguageDesc(
-        name='c-dsl',
+    register_language(
+        'c-dsl',
         pattern='*.c',
         description='Test Lang C',
         metamodel=c_mm)
-
-    clear_language_registrations()
-    register_language(a_dsl)
-    register_language(b_dsl)
-    register_language(c_dsl)
 
     #################################
     # MODEL PARSING

--- a/textx/__init__.py
+++ b/textx/__init__.py
@@ -7,6 +7,8 @@ from textx.exceptions import TextXError, TextXSyntaxError, \
 from textx.scoping.tools import textx_isinstance
 from textx.registration import (LanguageDesc, GeneratorDesc,
                                 register_language, register_generator,
+                                language_descriptions, language_description,
+                                generator_descriptions, generator_description,
                                 clear_language_registrations,
                                 clear_generator_registrations,
                                 languages_for_file,

--- a/textx/registration.py
+++ b/textx/registration.py
@@ -16,8 +16,9 @@ class LanguageDesc:
         name (str): the name/ID of the language (must be unique)
         pattern (str): filename pattern for models (e.g. "*.data")
         description (str): A short description of the language
-        metamodel (callable): A callable that returns configured meta-model or the
-            metamodel itself (if a single specific instance is desired)
+        metamodel (callable): A callable that returns configured meta-model
+            or the metamodel itself (if a single specific instance is
+            desired)
     """
 
     def __init__(self, name, pattern=None, description='', metamodel=None):
@@ -178,8 +179,8 @@ def metamodel_for_language(language_name):
     if language_name not in metamodels:
         from textx.metamodel import TextXMetaModel, TextXMetaMetaModel
         language = language_description(language_name)
-        if (isinstance(language.metamodel, TextXMetaModel) or
-            isinstance(language.metamodel, TextXMetaMetaModel)):
+        if (isinstance(language.metamodel, TextXMetaModel)
+                or isinstance(language.metamodel, TextXMetaMetaModel)):
             metamodels[language_name] = language.metamodel
         else:
             metamodel = language.metamodel()

--- a/textx/registration.py
+++ b/textx/registration.py
@@ -123,13 +123,30 @@ def generator_for_language_target(language_name, target_name):
     return generator_desc.generator
 
 
-def register_language(language_desc):
+def register_language(language_desc_or_name, pattern=None, description='',
+                      metamodel=None):
     """
     Programmatically register a language.
+
+    Args:
+        language_desc_or_name (LanguageDesc or str): If LanguageDesc is given
+            other parameters are not used.
+        For other parameters see `LanguageDesc`.
     """
     global languages
     if languages is None:
         language_descriptions()
+
+    if type(language_desc_or_name) is not LanguageDesc:
+        language_desc = LanguageDesc(
+            name=language_desc_or_name,
+            pattern=pattern,
+            description=description,
+            metamodel=metamodel
+        )
+    else:
+        language_desc = language_desc_or_name
+
     if language_desc.name.lower() in languages:
         raise TextXRegistrationError(
             'Language "{}" already registered.'.format(language_desc.name))
@@ -145,13 +162,30 @@ def clear_language_registrations():
     metamodels = {}
 
 
-def register_generator(generator_desc):
+def register_generator(generator_desc_or_language, target=None, description='',
+                       generator=None):
     """
     Programmatically register a generator.
+
+    Args:
+        generator_desc_or_language (GeneratorDesc or str): If GeneratorDesc is
+            given other parameters are not used.
+        For other parameters see `GeneratorDesc`.
     """
     global generators
     if generators is None:
         generator_descriptions()
+
+    if type(generator_desc_or_language) is not GeneratorDesc:
+        generator_desc = GeneratorDesc(
+            language=generator_desc_or_language,
+            target=target,
+            description=description,
+            generator=generator
+        )
+    else:
+        generator_desc = generator_desc_or_language
+
     lang_gens = generators.setdefault(generator_desc.language.lower(), {})
     if generator_desc.target.lower() in lang_gens:
         raise TextXRegistrationError(

--- a/textx/registration.py
+++ b/textx/registration.py
@@ -199,8 +199,8 @@ def languages_for_file(file_name_or_pattern):
     """
     file_languages = []
     for language in language_descriptions().values():
-        pmatch = fnmatch.fnmatch(file_name_or_pattern, language.pattern)
-        if file_name_or_pattern == language.pattern or pmatch:
+        if file_name_or_pattern == language.pattern \
+                or fnmatch.fnmatch(file_name_or_pattern, language.pattern):
             file_languages.append(language)
     return file_languages
 

--- a/textx/registration.py
+++ b/textx/registration.py
@@ -16,7 +16,8 @@ class LanguageDesc:
         name (str): the name/ID of the language (must be unique)
         pattern (str): filename pattern for models (e.g. "*.data")
         description (str): A short description of the language
-        metamodel (callable): A callable that returns configured meta-model
+        metamodel (callable): A callable that returns configured meta-model or the
+            metamodel itself (if a single specific instance is desired)
     """
 
     def __init__(self, name, pattern=None, description='', metamodel=None):
@@ -177,13 +178,17 @@ def metamodel_for_language(language_name):
     if language_name not in metamodels:
         from textx.metamodel import TextXMetaModel, TextXMetaMetaModel
         language = language_description(language_name)
-        metamodel = language.metamodel()
-        if not (isinstance(metamodel, TextXMetaModel) or
-                isinstance(metamodel, TextXMetaMetaModel)):
-            raise TextXRegistrationError(
-                'Meta-model type for language "{}" is "{}".'
-                .format(language_name, type(metamodel).__name__))
-        metamodels[language_name] = language.metamodel()
+        if (isinstance(language.metamodel, TextXMetaModel) or
+            isinstance(language.metamodel, TextXMetaMetaModel)):
+            metamodels[language_name] = language.metamodel
+        else:
+            metamodel = language.metamodel()
+            if not (isinstance(metamodel, TextXMetaModel) or
+                    isinstance(metamodel, TextXMetaMetaModel)):
+                raise TextXRegistrationError(
+                    'Meta-model type for language "{}" is "{}".'
+                    .format(language_name, type(metamodel).__name__))
+            metamodels[language_name] = language.metamodel()
     return metamodels[language_name]
 
 
@@ -193,8 +198,8 @@ def languages_for_file(file_name_or_pattern):
     """
     file_languages = []
     for language in language_descriptions().values():
-        if file_name_or_pattern == language.pattern \
-           or fnmatch.fnmatch(file_name_or_pattern, language.pattern):
+        pmatch = fnmatch.fnmatch(file_name_or_pattern, language.pattern)
+        if file_name_or_pattern == language.pattern or pmatch:
             file_languages.append(language)
     return file_languages
 

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -142,16 +142,24 @@ class GlobalModelRepository(object):
         Returns:
             the list of loaded models
         """
-        from textx import metamodel_for_file
+        from textx import metamodel_for_file, get_metamodel
         if model:
             self.update_model_in_repo_based_on_filename(model)
+            the_metamodel = get_metamodel(model) # default metamodel
+        else:
+            the_metamodel = None
         filenames = glob.glob(filename_pattern, **glob_args)
         if len(filenames) == 0:
             raise IOError(
                 errno.ENOENT, os.strerror(errno.ENOENT), filename_pattern)
         loaded_models = []
         for filename in filenames:
-            the_metamodel = metamodel_for_file(filename)
+            try:
+                the_metamodel = metamodel_for_file(filename)
+                # TODO, I would prefer to query if the language was found...
+            except:
+                if the_metamodel is None:  # no metamodel defined...
+                    raise
             loaded_models.append(
                 self.load_model(the_metamodel, filename, is_main_model,
                                 encoding=encoding,

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -66,11 +66,11 @@ class MetaModelProvider(object):
 
 
 def metamodel_for_file_or_default_metamodel(filename, the_metamodel):
-    from textx import metamodel_for_file, get_metamodel
+    from textx import metamodel_for_file
     try:
         the_metamodel = metamodel_for_file(filename)
         # TODO, I would prefer to query if the language was found...
-    except:
+    except Exception:
         if the_metamodel is None:  # no metamodel defined...
             raise
     return the_metamodel
@@ -156,7 +156,7 @@ class GlobalModelRepository(object):
         from textx import get_metamodel
         if model is not None:
             self.update_model_in_repo_based_on_filename(model)
-            the_metamodel = get_metamodel(model) # default metamodel
+            the_metamodel = get_metamodel(model)  # default metamodel
         else:
             the_metamodel = None
         filenames = glob.glob(filename_pattern, **glob_args)
@@ -188,7 +188,7 @@ class GlobalModelRepository(object):
         Returns:
             the loaded model
         """
-        from textx import metamodel_for_file, get_metamodel
+        from textx import get_metamodel
         if model:
             self.update_model_in_repo_based_on_filename(model)
         for the_path in search_path:

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -13,13 +13,11 @@ from os.path import join, exists
 
 def metamodel_for_file_or_default_metamodel(filename, the_metamodel):
     from textx import metamodel_for_file
+    from textx.exceptions import TextXRegistrationError
     try:
-        the_metamodel = metamodel_for_file(filename)
-        # TODO, I would prefer to query if the language was found...
-    except Exception:
-        if the_metamodel is None:  # no metamodel defined...
-            raise
-    return the_metamodel
+        return metamodel_for_file(filename)
+    except TextXRegistrationError:
+        return the_metamodel
 
 
 # -----------------------------------------------------------------------------

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -11,60 +11,6 @@ import errno
 from os.path import join, exists
 
 
-class MetaModelProvider(object):
-    """
-    This class has the responsibility to provide a meta model for a given file
-    to be loaded. This is a global resource (no objects, just this class).
-
-    You can register meta model instances for given file patterns. If no
-    pattern matches, the same meta model as for the underlying model is
-    utilized.
-
-    Example:
-
-        # create meta models
-
-        mm_components   = metamodel_from_file('Components.tx')
-        mm_users        = metamodel_from_file('Users.tx')
-
-        # register meta models
-
-        scoping.MetaModelProvider.add_metamodel("*.components", mm_components)
-        scoping.MetaModelProvider.add_metamodel("*.users", mm_users)
-
-    """
-    _pattern_to_metamodel = {}  # pattern:metamodel
-
-    @staticmethod
-    def add_metamodel(pattern, the_metamodel):
-        if MetaModelProvider.knows(pattern):
-            raise Exception("pattern {} already registered".format(pattern))
-        MetaModelProvider._pattern_to_metamodel[pattern] = the_metamodel
-
-    @staticmethod
-    def clear():
-        MetaModelProvider._pattern_to_metamodel = {}
-
-    @staticmethod
-    def knows(pattern):
-        return pattern in MetaModelProvider._pattern_to_metamodel.keys()
-
-    @staticmethod
-    def get_metamodel(parent_model, filename):
-        from textx.model import get_metamodel
-        import fnmatch
-        for p, mm in MetaModelProvider._pattern_to_metamodel.items():
-            if fnmatch.fnmatch(filename, p):
-                # print("loading model {} with special mm".format(filename));
-                return mm
-        # print("loading model {} with present mm".format(filename))
-        if parent_model:
-            return get_metamodel(parent_model)
-        else:
-            raise Exception(
-                "unexpected: no meta model found for {}".format(filename))
-
-
 def metamodel_for_file_or_default_metamodel(filename, the_metamodel):
     from textx import metamodel_for_file
     try:


### PR DESCRIPTION
A quickfix proposal for #177: "removed MetaModelProvider", fixed some tests.

## Major changes
 * removed MetaModelProvider
 * allow - in addition to a metamodel factory function - also to register a metamodel itself. This should
allow to register a concrete instance as well... **comments?**
 * Fixed importUri metamodel retrieving: allow old behavior to use the current metamodel as fallback: **TBC**: can we have a check function for the existence of a language (instead of try/except, as I implemented it). -- see: ```metamodel_for_file_or_default_metamodel``` in textx/scoping/_ _ init _ _ .py

## Minor changes 
 * fixed some tests regarding model registration

## Misc
 * Note for the commit messages: we can squash everything together, after we reviewed and adapted the code...
 * Tests are OK now, but coverage is below 80%

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated
- [x] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`).


[commit messages]: https://chris.beams.io/posts/git-commit/
