### PR TITLE
Fix #182 Better handling of match rule object processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ please take a look at related PRs and issues and see if the change affects you.
      
 ### Fixed
 
+  - Calling of match rule object processors ([#183], [#182], [#96])
   - Circular rule references in grammars ([#173], [#159], [#155])
   - Assertion error while calling object processors with multi meta models
     (extended grammars) and custom types ([#141], [#140])
@@ -374,6 +375,8 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#183]: https://github.com/textX/textX/pull/183
+[#182]: https://github.com/textX/textX/issues/182
 [#174]: https://github.com/textX/textX/pull/174
 [#173]: https://github.com/textX/textX/pull/173
 [#168]: https://github.com/textX/textX/pull/168
@@ -406,6 +409,7 @@ please take a look at related PRs and issues and see if the change affects you.
 [#99]: https://github.com/textX/textX/pull/99
 [#98]: https://github.com/textX/textX/pull/98
 [#97]: https://github.com/textX/textX/issues/97
+[#96]: https://github.com/textX/textX/issues/96
 [#93]: https://github.com/textX/textX/pull/93
 [#92]: https://github.com/textX/textX/pull/92
 

--- a/tests/functional/regressions/test_issue96.py
+++ b/tests/functional/regressions/test_issue96.py
@@ -29,3 +29,39 @@ def test_issue96_object_processor_on_match_rule_not_called():
 
     first_param = mymodel.parameters.parameters[0]
     assert isinstance(first_param, float)
+
+
+def test_issue96_object_processor_on_multiple_alternatives_not_called():
+
+    grammar = r"""
+    Command:
+        name=ID parameters=ParameterList
+    ;
+
+    ParameterList:
+        '(' parameters*=Parameter ')'
+    ;
+
+    Parameter:
+        value=ExplicitFloat | value=INT
+    ;
+
+    ExplicitFloat:
+        /-?\d+\.\d+/
+    ;
+    """
+
+    code = """
+    mycommand(0.1 1)
+    """
+    mm = metamodel_from_str(grammar)
+
+    mm.register_obj_processors({
+        'Parameter': lambda x: x.value,
+        'ExplicitFloat': lambda x: float(x)})
+
+    mymodel = mm.model_from_str(code)
+
+    first_param = mymodel.parameters.parameters[0]
+
+    assert isinstance(first_param, float)

--- a/tests/functional/regressions/test_issue96.py
+++ b/tests/functional/regressions/test_issue96.py
@@ -1,0 +1,31 @@
+from __future__ import unicode_literals
+from textx import metamodel_from_str
+
+
+def test_issue96_object_processor_on_match_rule_not_called():
+    grammar = r"""
+    Command:
+        name=ID parameters=ParameterList
+    ;
+
+    ParameterList:
+        '(' parameters*=Parameter ')'
+    ;
+    Parameter:
+        ExplicitFloat
+    ;
+    ExplicitFloat:
+        /-?\d+\.\d+/
+    ;
+    """
+
+    code = """
+    mycommand(0.1 1.1)
+    """
+    mm = metamodel_from_str(grammar)
+    mm.register_obj_processors({'ExplicitFloat': lambda x: float(x)})
+
+    mymodel = mm.model_from_str(code)
+
+    first_param = mymodel.parameters.parameters[0]
+    assert isinstance(first_param, float)

--- a/tests/functional/test_processors.py
+++ b/tests/functional/test_processors.py
@@ -117,7 +117,7 @@ def test_object_processor_replace_object():
     assert len(first.seconds) == 3
     assert first.seconds[0] == 17
 
-    assert first.c == '[dfdf]'
+    assert first.c == '["dfdf"]'
 
 
 def test_obj_processor_simple_match_rule():
@@ -180,11 +180,58 @@ def test_base_type_obj_processor_override():
     ;
     """
 
+    def to_float_with_str_check(x):
+        assert type(x) is text
+        return float(x)
+
     processors = {
-        'INT': lambda x: float(x)
+        'INT': to_float_with_str_check
     }
     mm = metamodel_from_str(grammar)
     mm.register_obj_processors(processors)
     m = mm.model_from_str('begin 34 end')
 
     assert type(m.i) is float
+
+
+def test_custom_base_type_with_builtin_alternatives():
+    grammar = r"""
+    Model: i*=MyNumber;
+    MyNumber: MyFloat | INT;
+    MyFloat:  /[+-]?(((\d+\.(\d*)?|\.\d+)([eE][+-]?\d+)?)|((\d+)([eE][+-]?\d+)))(?<=[\w\.])(?![\w\.])/;
+    """  # noqa
+
+    mm = metamodel_from_str(grammar)
+    model = mm.model_from_str('3.4 6')
+    assert type(model.i[0]) is text
+    assert type(model.i[1]) is int
+
+    mm.register_obj_processors({'MyFloat': lambda x: float(x)})
+    model = mm.model_from_str('3.4 6')
+    assert type(model.i[0]) is float
+    assert type(model.i[1]) is int
+
+
+def test_nested_match_rules():
+    """
+    Test calling processors for nested match rules.
+    """
+    grammar = r"""
+    Model: objects*=MyObject;
+    MyObject: HowMany | MyNumber;
+    HowMany: '+'+;  // We will register processor that returns a count of '+'
+    MyNumber: MyFloat | INT;
+    MyFloat:  /[+-]?(((\d+\.(\d*)?|\.\d+)([eE][+-]?\d+)?)|((\d+)([eE][+-]?\d+)))(?<=[\w\.])(?![\w\.])/;
+    """  # noqa
+
+    def howmany_processor(x):
+        return len(x)
+
+    mm = metamodel_from_str(grammar)
+    mm.register_obj_processors({'HowMany': howmany_processor,
+                                'MyFloat': lambda x: float(x)})
+    model = mm.model_from_str('3.4 ++ + ++ 6')
+    assert model.objects[0] == 3.4
+    assert model.objects[1] == 5
+    assert model.objects[2] == 6
+    assert type(model.objects[2]) is int

--- a/tests/functional/test_processors.py
+++ b/tests/functional/test_processors.py
@@ -235,3 +235,15 @@ def test_nested_match_rules():
     assert model.objects[1] == 5
     assert model.objects[2] == 6
     assert type(model.objects[2]) is int
+
+    # Now we will add another processor for `MyObject` to test if we can change
+    # the result returned from match processors lower in hierarchy.
+    def myobject_processor(x):
+        assert type(x) in [int, float]
+        return '#{}'.format(text(x))
+    mm.register_obj_processors({'HowMany': howmany_processor,
+                                'MyFloat': lambda x: float(x),
+                                'MyObject': myobject_processor})
+    model = mm.model_from_str('3.4 ++ + ++ 6')
+    assert model.objects[0] == '#3.4'
+    assert model.objects[1] == '#5'

--- a/textx/metamodel.py
+++ b/textx/metamodel.py
@@ -154,6 +154,16 @@ class TextXMetaModel(DebugPrinter):
         # Registered object processors
         self.obj_processors = {}
 
+        # Match rule and base type conversion callables
+        self.type_convertors = {
+            'BOOL': lambda x: x == '1' or x.lower() == 'true',
+            'INT': lambda x: int(x),
+            'FLOAT': lambda x: float(x),
+            'STRICTFLOAT': lambda x: float(x),
+            'STRING': lambda x: x[1:-1].replace(r'\"',
+                                                r'"').replace(r"\'", "'"),
+        }
+
         # Registered scope provider
         self.scope_providers = {}
 
@@ -423,6 +433,12 @@ class TextXMetaModel(DebugPrinter):
         clazz._tx_attrs[name] = attr
         return attr
 
+    def convert(self, value, _type):
+        """
+        Convert instances of textx types and match rules to python types.
+        """
+        return self.type_convertors.get(_type, lambda x: x)(value)
+
     def validate(self):
         """
         Validates metamodel. Called after construction to check for some
@@ -578,6 +594,7 @@ class TextXMetaModel(DebugPrinter):
                 value=callable
         """
         self.obj_processors = obj_processors
+        self.type_convertors.update(obj_processors)
 
 
 def metamodel_from_str(lang_desc, metamodel=None, **kwargs):


### PR DESCRIPTION
This PR reworks calling of match rules object processors and fix #182. Now, rules are called during type conversion which should simplify thing and make overriding of default type more consistent.

This seems to fix various issues around calling object processors on match rules like the one reported on #96 



<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`).


[commit messages]: https://chris.beams.io/posts/git-commit/
