### PR TITLE
fix #166 Improve and simplify handling of abstract rule alternatives.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Changed
 
+  - Improved handling of abstract rules references. Improved the definition of
+    rules for various cases. Docs + tests ([#185], [#166])
   - CLI migrated to the [click] library ([#162])
   - Docs improvements ([#146], [#153], [#151]). Thanks simkimsia@GitHub.
   - `FQN` constuctor param `follow_loaded_models` removed and introduced
@@ -375,11 +377,13 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#185]: https://github.com/textX/textX/pull/185
 [#183]: https://github.com/textX/textX/pull/183
 [#182]: https://github.com/textX/textX/issues/182
 [#174]: https://github.com/textX/textX/pull/174
 [#173]: https://github.com/textX/textX/pull/173
 [#168]: https://github.com/textX/textX/pull/168
+[#166]: https://github.com/textX/textX/issues/166
 [#165]: https://github.com/textX/textX/pull/165
 [#164]: https://github.com/textX/textX/pull/164
 [#162]: https://github.com/textX/textX/pull/162

--- a/tests/functional/regressions/test_issue166.py
+++ b/tests/functional/regressions/test_issue166.py
@@ -1,0 +1,27 @@
+from __future__ import unicode_literals
+import textx
+
+
+def test_issue166_wrong_multiple_rule_reference():
+    """
+    Test wrongly detected referencing of multiple rules from a single abstract
+    rule alternative.
+    Reported in issue #166.
+    """
+    grammar = """
+    DSL:
+        commands*=BaseCommand;
+    BaseCommand:
+        (Require | Group) '.'?;
+
+    Require:
+        'require' /[a-z]/;
+    Group:
+        'group' hello=/[0-9]/;
+    """
+
+    metamodel = textx.metamodel_from_str(grammar)
+    assert metamodel
+    model = metamodel.model_from_str('require a. group 4')
+    assert model.commands[0] == 'requirea'
+    assert model.commands[1].hello == '4'

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -347,18 +347,9 @@ class TextXVisitor(PTNodeVisitor):
                                 if rule._tx_class._tx_type != RULE_MATCH and\
                                         rule._tx_class not in inh_by:
                                     inh_by.append(rule._tx_class)
-                            return 1
                         else:
-                            rule_references = 0
                             for r in rule.nodes:
-                                rule_references += \
-                                    _add_reffered_classes(r, inh_by)
-                            if rule_references > 1:
-                                raise TextXSemanticError(
-                                    'Referencing multiple rules from '
-                                    'a single choice of abstract rule "{}" '
-                                    'is not allowed.'.format(cls.__name__))
-                            return rule_references
+                                _add_reffered_classes(r, inh_by)
 
                     if type(rule) is OrderedChoice:
                         for r in rule.nodes:

--- a/textx/model.py
+++ b/textx/model.py
@@ -345,8 +345,14 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                 # with matched concrete meta-class down the inheritance tree.
                 # Abstract meta-class should never be instantiated.
                 if len(node) > 1:
-                    return process_node(next(n for n in node
-                                             if type(n) is not Terminal))
+                    try:
+                        return process_node(
+                            next(n for n in node
+                                 if type(n) is not Terminal
+                                 and n.rule._tx_class is not RULE_MATCH))
+                    except StopIteration:
+                        # All nodes are match rules, do concatenation
+                        return ''.join(text(n) for n in node)
                 else:
                     return process_node(node[0])
             elif mclass._tx_type == RULE_MATCH:


### PR DESCRIPTION
This PR further simplifies and makes abstract rules more flexible by allowing multiple rules reference from a single alternative with the following:
- If all rule references in a single alternative are match rules return concatenated string as a result
- If there is a common rule reference use it as a result and ignore all other match rules (only use them for parsing)
- If there are multiple common rule references the result will be the first in the order of definition

TODO:
- [x] Update docs
- [x] Update changelog

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`).


[commit messages]: https://chris.beams.io/posts/git-commit/
