### PR TITLE
cleanup localscope implementtation (`RelativeName` and `ExtRelativeName`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Made scope provider implementation of `RelativeName` and `ExtRelativeName`
     more readable ([#186]). Minor functional changes, not very probable to have
     any impact (only affects model-paths containing a list not at the end of the
-    path; see [#186]).
+    path; see [#186]). Possible **(BIC)**.
   - CLI migrated to the [click] library ([#162])
   - Docs improvements ([#146], [#153], [#151]). Thanks simkimsia@GitHub.
   - `FQN` constuctor param `follow_loaded_models` removed and introduced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Changed
 
+  - Made scope provider implementation of `RelativeName` and `ExtRelativeName`
+    more readable ([#186]). Minor functional changes, not very probable to have
+    any impact (only affects model-paths containing a list not at the end of the
+    path; see [#186]).
   - CLI migrated to the [click] library ([#162])
   - Docs improvements ([#146], [#153], [#151]). Thanks simkimsia@GitHub.
   - `FQN` constuctor param `follow_loaded_models` removed and introduced

--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -90,32 +90,32 @@ We provide some standard scope providers:
    name loopup**.
    Example: see [tests/test_scoping/test_full_qualified_name.py](https://github.com/textX/textX/blob/master/tests/functional/test_scoping/test_full_qualified_name.py).
    
-   A central feature of this scope provider is, that it **traverses the model
-   tree and searches for a matching sequence of named objects** (objects with
-   an attribute name matching parts of the full qualified name separated by 
-   dots). You can also provide a **callback** (`scope_redirection_logic`) to specify
-   that certain named objects are not searched recursively, but are replaced
-   by a list of objects instead, which are searched in place of the current object.
-   With this feature you can create, e.g., **namespace/package aliases** in your 
-   language. You can also activate a **python like module import behavior** 
-   for your language (with `textx.scoping.providers.FQNImportURI`), which is based 
-   on this callback.
-   Example: see [tests/functional/regressions/test_issue103_python_like_import.py](https://github.com/textX/textX/blob/master/tests/functional/regressions/test_issue103_python_like_import.py).
-
-        package p1 {
-            package p2 {
-                class a {};
+       A central feature of this scope provider is, that it **traverses the model
+       tree and searches for a matching sequence of named objects** (objects with
+       an attribute name matching parts of the full qualified name separated by 
+       dots). You can also provide a **callback** (`scope_redirection_logic`) to specify
+       that certain named objects are not searched recursively, but are replaced
+       by a list of objects instead, which are searched in place of the current object.
+       With this feature you can create, e.g., **namespace/package aliases** in your 
+       language. You can also activate a **python like module import behavior** 
+       for your language (with `textx.scoping.providers.FQNImportURI`), which is based 
+       on this callback.
+       Example: see [tests/functional/regressions/test_issue103_python_like_import.py](https://github.com/textX/textX/blob/master/tests/functional/regressions/test_issue103_python_like_import.py).
+    
+            package p1 {
+                package p2 {
+                    class a {};
+                }
             }
-        }
-        using p1.p2 as main
-        var x = new p1.p2.a()
-        var y = new main.a()
-        
-   Note: Except in the context of the scope_redirection_logic (see above), the FQN does
-   not take Postponed (unresolved) references into account. The reason is that
-   this would create a much more complex decision logic to decide which reference
-   needs to be resolved first. The purpose of the FQN is to identify direct instances
-   of model objects, and no references.
+            using p1.p2 as main
+            var x = new p1.p2.a()
+            var y = new main.a()
+            
+       Note: Except in the context of the scope_redirection_logic (see above), the FQN does
+       not take Postponed (unresolved) references into account. The reason is that
+       this would create a much more complex decision logic to decide which reference
+       needs to be resolved first. The purpose of the FQN is to identify direct instances
+       of model objects, and no references.
    
  * `textx.scoping.providers.ImportURI`: This a provider which **allows to load
    additional modules** for lookup.
@@ -127,17 +127,19 @@ We provide some standard scope providers:
    additional attribute `_tx_loaded_models` which is a list of the loaded
    models by this rule instance.
    Example: see [tests/test_scoping/test_import_module.py](https://github.com/textX/textX/blob/master/tests/functional/test_scoping/test_import_module.py).
+   
     - `FQNImportURI` (decorated scope provider)
     - `PlainNameImportURI` (decorated scope provider)
 
-   You can use ***globbing*** (import "*.data") with the ImportURI feature.
-   This is implemented via the python "glob" module. Arguments can be passed to
-   the glob.glob function (glob_args), e.g., to enable recursive globbing.
-   Alternatively, you can also specify a list of ***search directories***.
-   In this case globbing is not allowed and is disabled (reason: it is
-   unclear if the user wants to glob over all search path entries or to stop
-   after the first match).
-   Example: see [tests/test_scoping/test_import_module_search_path_issue66.py](https://github.com/textX/textX/blob/master/tests/functional/test_scoping/test_import_module_search_path_issue66.py).
+       You can use ***globbing*** (import "*.data") with the ImportURI feature.
+       This is implemented via the python "glob" module. Arguments can be passed to
+       the glob.glob function (glob_args), e.g., to enable recursive globbing.
+       Alternatively, you can also specify a list of ***search directories***.
+       In this case globbing is not allowed and is disabled (reason: it is
+       unclear if the user wants to glob over all search path entries or to stop
+       after the first match).
+       Example: see [tests/test_scoping/test_import_module_search_path_issue66.py](https://github.com/textX/textX/blob/master/tests/functional/test_scoping/test_import_module_search_path_issue66.py).
+
  * `textx.scoping.providers.GlobalRepo`: This is a provider where **you initially
    need to specifiy the model files to be loaded and used for lookup**. Like
    for `ImportURI` you need to provide another scope provider for the concrete
@@ -153,21 +155,25 @@ We provide some standard scope providers:
        see ([tests/test_scoping/importURI_variations/test_importURI_variations.py](https://github.com/textX/textX/blob/master/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py).
        
     - `textx.scoping.providers.PlainNameGlobalRepo` (decorated scope provider)
+
  * `textx.scoping.providers.RelativeName`: This is a scope provider to **resolve
-   relative lookups**: e.g., model-methods of a model-instance, defined by the
-   class associated with the model-instance. Typically, another reference (the
-   reference to the model-class of a model-instance) is used to determine the
-   concrete referenced object (e.g. the model-method, owned by a model-class).
-   Example: see [tests/test_scoping/test_local_scope.py](https://github.com/textX/textX/blob/master/tests/functional/test_scoping/test_local_scope.py).
+    relative lookups**: e.g., model-methods of a model-instance, defined by the
+    class associated with the model-instance. Typically, another reference (the
+    reference to the model-class of a model-instance) is used to determine the
+    concrete referenced object (e.g. the model-method, owned by a model-class).
+    Example: see [tests/test_scoping/test_local_scope.py](https://github.com/textX/textX/blob/master/tests/functional/test_scoping/test_local_scope.py).
+
+    The scope is defined by a model-path from the current object to (typically) 
+    a list containing named objects.
+
  * `textx.scoping.providers.ExtRelativeName`: The same as `RelativeName` **allowing
-   to model inheritance or chained lookups**.
-   Example: see [tests/test_scoping/test_local_scope.py](https://github.com/textX/textX/blob/master/tests/functional/test_scoping/test_local_scope.py).
-    - `RelativeName`: The scope is defined by a model-path from the current object to (typically) 
-        a list containing named objects.
-    - `ExtRelativeName`: The scope is defined by a model-path from the current object and *connected objects*
-        to (typically) a list containing named objects (similar to `RelativeName`). 
-        The *connected objects* are defined again by a model-path from one object 
-        to another named object or a list of named objects.
+    to model inheritance or chained lookups**.
+    Example: see [tests/test_scoping/test_local_scope.py](https://github.com/textX/textX/blob/master/tests/functional/test_scoping/test_local_scope.py).
+
+    The scope is defined by a model-path from the current object and *connected objects*
+    to (typically) a list containing named objects (similar to `RelativeName`). 
+    The *connected objects* are defined again by a model-path from one object 
+to another named object or a list of named objects.
 
 ### Note on Uniqueness of Model Elements
 

--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -162,7 +162,12 @@ We provide some standard scope providers:
  * `textx.scoping.providers.ExtRelativeName`: The same as `RelativeName` **allowing
    to model inheritance or chained lookups**.
    Example: see [tests/test_scoping/test_local_scope.py](https://github.com/textX/textX/blob/master/tests/functional/test_scoping/test_local_scope.py).
-
+    - `RelativeName`: The scope is defined by a model-path from the current object to (typically) 
+        a list containing named objects.
+    - `ExtRelativeName`: The scope is defined by a model-path from the current object and *connected objects*
+        to (typically) a list containing named objects (similar to `RelativeName`). 
+        The *connected objects* are defined again by a model-path from one object 
+        to another named object or a list of named objects.
 
 ### Note on Uniqueness of Model Elements
 

--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -163,7 +163,7 @@ We provide some standard scope providers:
     concrete referenced object (e.g. the model-method, owned by a model-class).
     Example: see [tests/test_scoping/test_local_scope.py](https://github.com/textX/textX/blob/master/tests/functional/test_scoping/test_local_scope.py).
 
-    The scope is defined by a model-path from the current object to (typically) 
+    The scope is defined by a model-path from the current object to 
     a list containing named objects.
 
  * `textx.scoping.providers.ExtRelativeName`: The same as `RelativeName` **allowing
@@ -171,9 +171,9 @@ We provide some standard scope providers:
     Example: see [tests/test_scoping/test_local_scope.py](https://github.com/textX/textX/blob/master/tests/functional/test_scoping/test_local_scope.py).
 
     The scope is defined by a model-path from the current object and *connected objects*
-    to (typically) a list containing named objects (similar to `RelativeName`). 
+    to a list containing named objects (similar to `RelativeName`). 
     The *connected objects* are defined again by a model-path from one object 
-to another named object or a list of named objects.
+    to another named object or a list of named objects.
 
 ### Note on Uniqueness of Model Elements
 

--- a/tests/functional/examples/test_hierarchical_data_structures_referencing_attributes.py
+++ b/tests/functional/examples/test_hierarchical_data_structures_referencing_attributes.py
@@ -63,7 +63,8 @@ def test_referencing_attributes():
         index = reference.refs.index(refItem)
         assert (index >= 0)
 
-        base = reference.instance if index == 0 else reference.refs[index - 1].valref
+        base = reference.instance if index == 0 \
+            else reference.refs[index - 1].valref
         if base is None or base.type is None:
             return Postponed()
         x = get_named_obj_in_list(base.type.vals, attr_ref.obj_name)

--- a/tests/functional/examples/test_hierarchical_data_structures_referencing_attributes.py
+++ b/tests/functional/examples/test_hierarchical_data_structures_referencing_attributes.py
@@ -46,33 +46,43 @@ def test_referencing_attributes():
         val b1: B
         val a: A
     }
-
     instance d: D
     instance a: A
-
     reference d.c.b.a.x
     reference d.b1.a.x
     reference a.x
     '''
 
     def ref_scope(refItem, attr, attr_ref):
-        from textx.scoping.tools import get_referenced_object
+        from textx.scoping.tools import get_named_obj_in_list
         from textx.scoping import Postponed
+        from textx import textx_isinstance
         reference = refItem.parent
         if reference is None:
             return Postponed()
         index = reference.refs.index(refItem)
         assert (index >= 0)
         if index == 0:
-            return get_referenced_object(
-                None, reference,
-                "instance.type.vals.{}".format(attr_ref.obj_name),
-                attr_ref.cls)
+            if reference.instance is None:
+                return Postponed()
+            if reference.instance.type is None:
+                return Postponed()
+            x = get_named_obj_in_list(
+                reference.instance.type.vals,
+                attr_ref.obj_name)
         else:
-            return get_referenced_object(
-                None, reference.refs[index - 1],
-                "valref.type.vals.{}".format(attr_ref.obj_name),
-                attr_ref.cls)
+            if reference.refs[index - 1].valref is None:
+                return Postponed()
+            if reference.refs[index - 1].valref.type is None:
+                return Postponed()
+            x = get_named_obj_in_list(
+                reference.refs[index - 1].valref.type.vals,
+                attr_ref.obj_name)
+        if index == len(reference.refs)-1:
+            if not textx_isinstance(x, attr.cls):
+                print(x)
+                return None
+        return x
 
     mm = metamodel_from_str(grammar)
     mm.register_scope_providers({
@@ -111,7 +121,7 @@ def test_referencing_attributes():
 
     # error: B.a is not of type A
     with raises(textx.exceptions.TextXSemanticError,
-                match=r'.*Unknown object.*x.*'):
+                match=r'.*Unresolvable cross references.*x.*'):
         mm.model_from_str('''
         struct A { val x }
         struct B { val a }

--- a/tests/functional/examples/test_hierarchical_data_structures_referencing_attributes.py
+++ b/tests/functional/examples/test_hierarchical_data_structures_referencing_attributes.py
@@ -62,22 +62,12 @@ def test_referencing_attributes():
             return Postponed()
         index = reference.refs.index(refItem)
         assert (index >= 0)
-        if index == 0:
-            if reference.instance is None:
-                return Postponed()
-            if reference.instance.type is None:
-                return Postponed()
-            x = get_named_obj_in_list(
-                reference.instance.type.vals,
-                attr_ref.obj_name)
-        else:
-            if reference.refs[index - 1].valref is None:
-                return Postponed()
-            if reference.refs[index - 1].valref.type is None:
-                return Postponed()
-            x = get_named_obj_in_list(
-                reference.refs[index - 1].valref.type.vals,
-                attr_ref.obj_name)
+
+        base = reference.instance if index == 0 else reference.refs[index - 1].valref
+        if base is None or base.type is None:
+            return Postponed()
+        x = get_named_obj_in_list(base.type.vals, attr_ref.obj_name)
+
         if index == len(reference.refs)-1:
             if not textx_isinstance(x, attr.cls):
                 print(x)

--- a/tests/functional/test_scoping/test_local_scope.py
+++ b/tests/functional/test_scoping/test_local_scope.py
@@ -310,3 +310,35 @@ def test_model_with_local_scope_wrong_type():
         my_meta_model.model_from_file(
             join(abspath(dirname(__file__)),
                  "components_model1", "example_wrong_type.components"))
+
+
+def test_model_with_local_scope_and_bad_model_path():
+    """
+    This is a basic test for the local scope provider
+    """
+    #################################
+    # META MODEL DEF
+    #################################
+
+    my_meta_model = metamodel_from_file(
+        join(abspath(dirname(__file__)),
+             'components_model1', 'Components.tx'))
+    my_meta_model.register_scope_providers({
+        "*.*": scoping_providers.FQN(),
+        "Connection.from_port":
+            # error (component is not a list)
+            scoping_providers.RelativeName("from_inst.component"),
+        "Connection.to_port":
+            scoping_providers.RelativeName("to_inst.component.slots"),
+    })
+
+    #################################
+    # MODEL PARSING
+    #################################
+
+    with raises(textx.exceptions.TextXError,
+                match=r'.*expected path to list in the model '
+                      + r'\(from_inst.component\).*'):
+        my_meta_model.model_from_file(
+            join(abspath(dirname(__file__)),
+                 "components_model1", "example.components"))

--- a/tests/functional/test_scoping/test_scoping_tools.py
+++ b/tests/functional/test_scoping/test_scoping_tools.py
@@ -75,9 +75,15 @@ def test_resolved_model_path_with_lists():
     middle_b = get_unique_named_object(my_model, "Middle")
     assert middle_a is middle_b
 
+    # test parent(...) with lists
     action2a_with_parent = resolved_model_path(
         action2a, "parent(Model).packages.usage.instances.action2", True)
     assert action2a_with_parent == action2a
+
+    # test "normal" parent with lists
+    action2a_with_parent2 = resolved_model_path(
+        action2a, "parent.instances.action2", True)
+    assert action2a_with_parent2 == action2a
 
     with raises(Exception, match=r'.*unexpected: got list in path for get_referenced_object.*'):
         resolved_model_path(my_model,
@@ -115,6 +121,7 @@ def test_resolved_model_path_simple_case():
     # TEST MODEL
     #################################
 
+    # test normal functionality
     outerA = resolved_model_path(model, "a")
     assert outerA.name == "OuterA"
     level0B = resolved_model_path(model, "b")
@@ -125,9 +132,16 @@ def test_resolved_model_path_simple_case():
     assert level2B.name == "Level2_B"
     innerA = resolved_model_path(model, "b.b.b.a")
     assert innerA.name == "InnerA"
+
+    # test parent(TYPE)
     outerA2 = resolved_model_path(model, "b.b.b.parent(Model).a")
     assert outerA2 == outerA
 
+    # test "normal" parent
+    outerA3 = resolved_model_path(model, "b.b.parent.parent.a")
+    assert outerA3 == outerA
+
+    # test "None"
     level3B_none = resolved_model_path(model, "b.b.b.b")
     assert level3B_none is None
     innerA_none1 = resolved_model_path(model, "b.b.b.b.a")
@@ -163,6 +177,7 @@ def test_resolved_model_path_simple_case_with_refs():
     # TEST MODEL
     #################################
 
+    # test normal functionality (with refs)
     level0B = resolved_model_path(model, "b")
     assert level0B.name == "Level0_B"
     level1B = resolved_model_path(model, "b.b")

--- a/tests/functional/test_scoping/test_scoping_tools.py
+++ b/tests/functional/test_scoping/test_scoping_tools.py
@@ -3,7 +3,7 @@ from os.path import dirname, abspath, join
 
 import textx.scoping.providers as scoping_providers
 from textx import metamodel_from_file, metamodel_from_str
-from textx.scoping.tools import resolved_model_path,\
+from textx.scoping.tools import resolve_model_path,\
     get_list_of_concatenated_objects
 from textx.scoping.tools import get_unique_named_object
 from textx import textx_isinstance
@@ -31,7 +31,7 @@ def test_textx_isinstace():
     assert textx_isinstance(c, A)
 
 
-def test_resolved_model_path_with_lists():
+def test_resolve_model_path_with_lists():
     #################################
     # META MODEL DEF
     #################################
@@ -63,35 +63,35 @@ def test_resolved_model_path_with_lists():
     # TEST MODEL
     #################################
 
-    action2a = resolved_model_path(my_model,
+    action2a = resolve_model_path(my_model,
                                      "packages.usage.instances.action2",
-                                   True)
+                                  True)
     action2b = get_unique_named_object(my_model, "action2")
     assert action2a is action2b
 
-    middle_a = resolved_model_path(my_model,
+    middle_a = resolve_model_path(my_model,
                                      "packages.base.components.Middle",
-                                   True)
+                                  True)
     middle_b = get_unique_named_object(my_model, "Middle")
     assert middle_a is middle_b
 
     # test parent(...) with lists
-    action2a_with_parent = resolved_model_path(
+    action2a_with_parent = resolve_model_path(
         action2a, "parent(Model).packages.usage.instances.action2", True)
     assert action2a_with_parent == action2a
 
     # test "normal" parent with lists
-    action2a_with_parent2 = resolved_model_path(
+    action2a_with_parent2 = resolve_model_path(
         action2a, "parent.instances.action2", True)
     assert action2a_with_parent2 == action2a
 
     with raises(Exception, match=r'.*unexpected: got list in path for get_referenced_object.*'):
-        resolved_model_path(my_model,
+        resolve_model_path(my_model,
                             "packages.usage.instances.action2",
-                            False)
+                           False)
 
 
-def test_resolved_model_path_simple_case():
+def test_resolve_model_path_simple_case():
     #################################
     # META MODEL DEF
     #################################
@@ -122,35 +122,35 @@ def test_resolved_model_path_simple_case():
     #################################
 
     # test normal functionality
-    outerA = resolved_model_path(model, "a")
+    outerA = resolve_model_path(model, "a")
     assert outerA.name == "OuterA"
-    level0B = resolved_model_path(model, "b")
+    level0B = resolve_model_path(model, "b")
     assert level0B.name == "Level0_B"
-    level1B = resolved_model_path(model, "b.b")
+    level1B = resolve_model_path(model, "b.b")
     assert level1B.name == "Level1_B"
-    level2B = resolved_model_path(model, "b.b.b")
+    level2B = resolve_model_path(model, "b.b.b")
     assert level2B.name == "Level2_B"
-    innerA = resolved_model_path(model, "b.b.b.a")
+    innerA = resolve_model_path(model, "b.b.b.a")
     assert innerA.name == "InnerA"
 
     # test parent(TYPE)
-    outerA2 = resolved_model_path(model, "b.b.b.parent(Model).a")
+    outerA2 = resolve_model_path(model, "b.b.b.parent(Model).a")
     assert outerA2 == outerA
 
     # test "normal" parent
-    outerA3 = resolved_model_path(model, "b.b.parent.parent.a")
+    outerA3 = resolve_model_path(model, "b.b.parent.parent.a")
     assert outerA3 == outerA
 
     # test "None"
-    level3B_none = resolved_model_path(model, "b.b.b.b")
+    level3B_none = resolve_model_path(model, "b.b.b.b")
     assert level3B_none is None
-    innerA_none1 = resolved_model_path(model, "b.b.b.b.a")
+    innerA_none1 = resolve_model_path(model, "b.b.b.b.a")
     assert innerA_none1 is None
-    innerA_none2 = resolved_model_path(model, "b.b.a")
+    innerA_none2 = resolve_model_path(model, "b.b.a")
     assert innerA_none2 is None
 
 
-def test_resolved_model_path_simple_case_with_refs():
+def test_resolve_model_path_simple_case_with_refs():
     #################################
     # META MODEL DEF
     #################################
@@ -178,11 +178,11 @@ def test_resolved_model_path_simple_case_with_refs():
     #################################
 
     # test normal functionality (with refs)
-    level0B = resolved_model_path(model, "b")
+    level0B = resolve_model_path(model, "b")
     assert level0B.name == "Level0_B"
-    level1B = resolved_model_path(model, "b.b")
+    level1B = resolve_model_path(model, "b.b")
     assert level1B.name == "Level1_B"
-    bref = resolved_model_path(model, "b.b.bref")
+    bref = resolve_model_path(model, "b.b.bref")
     assert bref.name == "Level0_B"
     assert bref == level0B
 

--- a/tests/functional/test_scoping/test_scoping_tools.py
+++ b/tests/functional/test_scoping/test_scoping_tools.py
@@ -10,6 +10,7 @@ from textx import textx_isinstance
 from textx import get_children_of_type
 from pytest import raises
 
+
 def test_textx_isinstace():
     grammar = \
         '''
@@ -64,13 +65,13 @@ def test_resolve_model_path_with_lists():
     #################################
 
     action2a = resolve_model_path(my_model,
-                                     "packages.usage.instances.action2",
+                                  "packages.usage.instances.action2",
                                   True)
     action2b = get_unique_named_object(my_model, "action2")
     assert action2a is action2b
 
     middle_a = resolve_model_path(my_model,
-                                     "packages.base.components.Middle",
+                                  "packages.base.components.Middle",
                                   True)
     middle_b = get_unique_named_object(my_model, "Middle")
     assert middle_a is middle_b
@@ -85,9 +86,10 @@ def test_resolve_model_path_with_lists():
         action2a, "parent.instances.action2", True)
     assert action2a_with_parent2 == action2a
 
-    with raises(Exception, match=r'.*unexpected: got list in path for get_referenced_object.*'):
+    with raises(Exception, match=r'.*unexpected: got list in path for '
+                                 r'get_referenced_object.*'):
         resolve_model_path(my_model,
-                            "packages.usage.instances.action2",
+                           "packages.usage.instances.action2",
                            False)
 
 
@@ -109,7 +111,7 @@ def test_resolve_model_path_simple_case():
     #################################
 
     model = mm.model_from_str(r'''
-        My_Model 
+        My_Model
             A: OuterA
             B: Level0_B
              -> B: Level1_B
@@ -167,7 +169,7 @@ def test_resolve_model_path_simple_case_with_refs():
     #################################
 
     model = mm.model_from_str(r'''
-        My_Model 
+        My_Model
             B: Level0_B
              -> B: Level1_B
              --> Level0_B

--- a/tests/functional/test_scoping/test_scoping_tools.py
+++ b/tests/functional/test_scoping/test_scoping_tools.py
@@ -3,7 +3,7 @@ from os.path import dirname, abspath, join
 
 import textx.scoping.providers as scoping_providers
 from textx import metamodel_from_file, metamodel_from_str
-from textx.scoping.tools import get_referenced_object, \
+from textx.scoping.tools import get_referenced_object,\
     get_list_of_concatenated_objects
 from textx.scoping.tools import get_unique_named_object
 from textx import textx_isinstance
@@ -63,13 +63,15 @@ def test_get_referenced_object():
     # TEST MODEL
     #################################
 
-    action2a = get_referenced_object(
-        None, my_model, "packages.usage.instances.action2")
+    action2a = get_referenced_object(my_model,
+                                     "packages.usage.instances.action2",
+                                     True)
     action2b = get_unique_named_object(my_model, "action2")
     assert action2a is action2b
 
-    middle_a = get_referenced_object(
-        None, my_model, "packages.base.components.Middle")
+    middle_a = get_referenced_object(my_model,
+                                     "packages.base.components.Middle",
+                                     True)
     middle_b = get_unique_named_object(my_model, "Middle")
     assert middle_a is middle_b
 

--- a/tests/functional/test_scoping/test_scoping_tools.py
+++ b/tests/functional/test_scoping/test_scoping_tools.py
@@ -3,12 +3,12 @@ from os.path import dirname, abspath, join
 
 import textx.scoping.providers as scoping_providers
 from textx import metamodel_from_file, metamodel_from_str
-from textx.scoping.tools import get_referenced_object,\
+from textx.scoping.tools import resolved_model_path,\
     get_list_of_concatenated_objects
 from textx.scoping.tools import get_unique_named_object
 from textx import textx_isinstance
 from textx import get_children_of_type
-
+from pytest import raises
 
 def test_textx_isinstace():
     grammar = \
@@ -31,7 +31,7 @@ def test_textx_isinstace():
     assert textx_isinstance(c, A)
 
 
-def test_get_referenced_object():
+def test_resolved_model_path_with_lists():
     #################################
     # META MODEL DEF
     #################################
@@ -63,17 +63,113 @@ def test_get_referenced_object():
     # TEST MODEL
     #################################
 
-    action2a = get_referenced_object(my_model,
+    action2a = resolved_model_path(my_model,
                                      "packages.usage.instances.action2",
-                                     True)
+                                   True)
     action2b = get_unique_named_object(my_model, "action2")
     assert action2a is action2b
 
-    middle_a = get_referenced_object(my_model,
+    middle_a = resolved_model_path(my_model,
                                      "packages.base.components.Middle",
-                                     True)
+                                   True)
     middle_b = get_unique_named_object(my_model, "Middle")
     assert middle_a is middle_b
+
+    action2a_with_parent = resolved_model_path(
+        action2a, "parent(Model).packages.usage.instances.action2", True)
+    assert action2a_with_parent == action2a
+
+    with raises(Exception, match=r'.*unexpected: got list in path for get_referenced_object.*'):
+        resolved_model_path(my_model,
+                            "packages.usage.instances.action2",
+                            False)
+
+
+def test_resolved_model_path_simple_case():
+    #################################
+    # META MODEL DEF
+    #################################
+
+    grammar = r'''
+        Model: name=ID a=A b=B;
+        A: 'A:' name=ID;
+        B: 'B:' name=ID ('->' b=B| '=' a=A );
+    '''
+
+    mm = metamodel_from_str(grammar)
+
+    #################################
+    # MODEL PARSING
+    #################################
+
+    model = mm.model_from_str(r'''
+        My_Model 
+            A: OuterA
+            B: Level0_B
+             -> B: Level1_B
+             -> B: Level2_B
+             = A: InnerA
+    ''')
+
+    #################################
+    # TEST MODEL
+    #################################
+
+    outerA = resolved_model_path(model, "a")
+    assert outerA.name == "OuterA"
+    level0B = resolved_model_path(model, "b")
+    assert level0B.name == "Level0_B"
+    level1B = resolved_model_path(model, "b.b")
+    assert level1B.name == "Level1_B"
+    level2B = resolved_model_path(model, "b.b.b")
+    assert level2B.name == "Level2_B"
+    innerA = resolved_model_path(model, "b.b.b.a")
+    assert innerA.name == "InnerA"
+    outerA2 = resolved_model_path(model, "b.b.b.parent(Model).a")
+    assert outerA2 == outerA
+
+    level3B_none = resolved_model_path(model, "b.b.b.b")
+    assert level3B_none is None
+    innerA_none1 = resolved_model_path(model, "b.b.b.b.a")
+    assert innerA_none1 is None
+    innerA_none2 = resolved_model_path(model, "b.b.a")
+    assert innerA_none2 is None
+
+
+def test_resolved_model_path_simple_case_with_refs():
+    #################################
+    # META MODEL DEF
+    #################################
+
+    grammar = r'''
+        Model: name=ID b=B;
+        B: 'B:' name=ID ('->' b=B | '-->' bref=[B] );
+    '''
+
+    mm = metamodel_from_str(grammar)
+
+    #################################
+    # MODEL PARSING
+    #################################
+
+    model = mm.model_from_str(r'''
+        My_Model 
+            B: Level0_B
+             -> B: Level1_B
+             --> Level0_B
+    ''')
+
+    #################################
+    # TEST MODEL
+    #################################
+
+    level0B = resolved_model_path(model, "b")
+    assert level0B.name == "Level0_B"
+    level1B = resolved_model_path(model, "b.b")
+    assert level1B.name == "Level1_B"
+    bref = resolved_model_path(model, "b.b.bref")
+    assert bref.name == "Level0_B"
+    assert bref == level0B
 
 
 def test_get_list_of_concatenated_objects():

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -640,8 +640,6 @@ class ExtRelativeName(object):
                 raise TextXError(
                     "expected path to list in the model ({})".format(
                         self.path_to_target))
-            for obj in tmp_list:
-                assert hasattr(obj, "name")
             tmp_list = list(filter(
                 lambda x: textx_isinstance(x, attr.cls) and
                 x.name.find(name_part) >= 0, tmp_list))

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -549,7 +549,14 @@ class RelativeName(object):
 
     def get_reference_propositions(self, obj, attr, name_part):
         """
-        (see ReferenceNameProposer)
+        retrieve a list of reference propositions.
+        Args:
+            obj: parent
+            attr: attribute
+            name_part: The name is used to build the list
+                (e.g. using a substring-like logic).
+        Returns:
+            the list of objects representing the proposed references
         """
         from textx.scoping.tools import get_referenced_object
         from textx import textx_isinstance
@@ -561,8 +568,9 @@ class RelativeName(object):
         assert isinstance(obj_list, list)
         for obj in obj_list:
             assert hasattr(obj, "name")
-        obj_list = filter(lambda x: textx_isinstance(x, attr.cls) and
-                                    x.name.find(name_part) >= 0, obj_list)
+        obj_list = filter(
+            lambda x: textx_isinstance(x, attr.cls) and
+            x.name.find(name_part) >= 0, obj_list)
 
         return list(obj_list)
 
@@ -594,11 +602,18 @@ class ExtRelativeName(object):
 
     def get_reference_propositions(self, obj, attr, name_part):
         """
-        (see ReferenceNameProposer)
+        retrieve a list of reference propositions.
+        Args:
+            obj: parent
+            attr: attribute
+            name_part: The name is used to build the list
+                (e.g. using a substring-like logic).
+        Returns:
+            the list of objects representing the proposed references
         """
         from textx.scoping.tools import get_referenced_object
         from textx import textx_isinstance
-        # find all containing objects
+        # find all all "connected" objects
         # (e.g. find all classes: the most derived
         # class, its base, the base of its base, etc.)
         from textx.scoping.tools import get_list_of_concatenated_objects
@@ -618,8 +633,9 @@ class ExtRelativeName(object):
             assert isinstance(tmp_list, list)
             for obj in tmp_list:
                 assert hasattr(obj, "name")
-            tmp_list = list(filter(lambda x: textx_isinstance(x, attr.cls) and
-                                             x.name.find(name_part) >= 0, tmp_list))
+            tmp_list = list(filter(
+                lambda x: textx_isinstance(x, attr.cls) and
+                x.name.find(name_part) >= 0, tmp_list))
             obj_list = obj_list + tmp_list
 
         return list(obj_list)

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -564,7 +564,6 @@ class RelativeName(object):
         if type(obj_list) is Postponed:
             self.postponed_counter += 1
             return obj_list
-        assert obj_list is not None
         # the referenced element must be a list
         # (else it is a design error in the path passed to
         # the RelativeName object).

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -558,9 +558,9 @@ class RelativeName(object):
         Returns:
             the list of objects representing the proposed references
         """
-        from textx.scoping.tools import get_referenced_object
+        from textx.scoping.tools import resolved_model_path
         from textx import textx_isinstance
-        obj_list = get_referenced_object(obj, self.path_to_container_object)
+        obj_list = resolved_model_path(obj, self.path_to_container_object)
         if type(obj_list) is Postponed:
             self.postponed_counter += 1
             return obj_list
@@ -615,13 +615,13 @@ class ExtRelativeName(object):
         Returns:
             the list of objects representing the proposed references
         """
-        from textx.scoping.tools import get_referenced_object
+        from textx.scoping.tools import resolved_model_path
         from textx import textx_isinstance
         # find all all "connected" objects
         # (e.g. find all classes: the most derived
         # class, its base, the base of its base, etc.)
         from textx.scoping.tools import get_list_of_concatenated_objects
-        def_obj = get_referenced_object(obj, self.path_to_definition_object)
+        def_obj = resolved_model_path(obj, self.path_to_definition_object)
         def_objs = get_list_of_concatenated_objects(
             def_obj, self.path_to_extension)
         # for all containing classes, collect all
@@ -632,7 +632,7 @@ class ExtRelativeName(object):
                 self.postponed_counter += 1
                 return def_obj
 
-            tmp_list = get_referenced_object(def_obj, self.path_to_target)
+            tmp_list = resolved_model_path(def_obj, self.path_to_target)
             assert tmp_list is not None
             # expected to point to  alist
             if not isinstance(tmp_list, list):

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -565,7 +565,14 @@ class RelativeName(object):
             self.postponed_counter += 1
             return obj_list
         assert obj_list is not None
-        assert isinstance(obj_list, list)
+        # the referenced element must be a list
+        # (else it is a design error in the path passed to
+        # the RelativeName object).
+        if not isinstance(obj_list, list):
+            from textx.exceptions import TextXError
+            raise TextXError(
+                "expected path to list in the model ({})".format(
+                    self.path_to_container_object))
         for obj in obj_list:
             assert hasattr(obj, "name")
         obj_list = filter(

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -572,8 +572,6 @@ class RelativeName(object):
             raise TextXError(
                 "expected path to list in the model ({})".format(
                     self.path_to_container_object))
-        for obj in obj_list:
-            assert hasattr(obj, "name")
         obj_list = filter(
             lambda x: textx_isinstance(x, attr.cls) and
             x.name.find(name_part) >= 0, obj_list)

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -634,7 +634,12 @@ class ExtRelativeName(object):
 
             tmp_list = get_referenced_object(def_obj, self.path_to_target)
             assert tmp_list is not None
-            assert isinstance(tmp_list, list)
+            # expected to point to  alist
+            if not isinstance(tmp_list, list):
+                from textx.exceptions import TextXError
+                raise TextXError(
+                    "expected path to list in the model ({})".format(
+                        self.path_to_target))
             for obj in tmp_list:
                 assert hasattr(obj, "name")
             tmp_list = list(filter(

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -558,9 +558,9 @@ class RelativeName(object):
         Returns:
             the list of objects representing the proposed references
         """
-        from textx.scoping.tools import resolved_model_path
+        from textx.scoping.tools import resolve_model_path
         from textx import textx_isinstance
-        obj_list = resolved_model_path(obj, self.path_to_container_object)
+        obj_list = resolve_model_path(obj, self.path_to_container_object)
         if type(obj_list) is Postponed:
             self.postponed_counter += 1
             return obj_list
@@ -615,13 +615,13 @@ class ExtRelativeName(object):
         Returns:
             the list of objects representing the proposed references
         """
-        from textx.scoping.tools import resolved_model_path
+        from textx.scoping.tools import resolve_model_path
         from textx import textx_isinstance
         # find all all "connected" objects
         # (e.g. find all classes: the most derived
         # class, its base, the base of its base, etc.)
         from textx.scoping.tools import get_list_of_concatenated_objects
-        def_obj = resolved_model_path(obj, self.path_to_definition_object)
+        def_obj = resolve_model_path(obj, self.path_to_definition_object)
         def_objs = get_list_of_concatenated_objects(
             def_obj, self.path_to_extension)
         # for all containing classes, collect all
@@ -632,7 +632,7 @@ class ExtRelativeName(object):
                 self.postponed_counter += 1
                 return def_obj
 
-            tmp_list = resolved_model_path(def_obj, self.path_to_target)
+            tmp_list = resolve_model_path(def_obj, self.path_to_target)
             assert tmp_list is not None
             # expected to point to  alist
             if not isinstance(tmp_list, list):

--- a/textx/scoping/tools.py
+++ b/textx/scoping/tools.py
@@ -169,9 +169,7 @@ def get_referenced_object(obj, dot_separated_name,
     names = dot_separated_name.split(".")
     match = re.match(r'parent\((\w+)\)', names[0])
 
-    if obj is None:
-        return None
-    elif type(obj) is Postponed:
+    if obj is None or type(obj) is Postponed:
         return obj
     elif type(obj) is list:
         if follow_named_element_in_lists:

--- a/textx/scoping/tools.py
+++ b/textx/scoping/tools.py
@@ -175,7 +175,8 @@ def get_referenced_object(obj, dot_separated_name,
         if follow_named_element_in_lists:
             next_obj = get_named_obj_in_list(obj, names[0])
         else:
-            raise Exception(
+            from textx.exceptions import TextXError
+            raise TextXError(
                 "unexpected: got list in path for get_referenced_object")
     elif match:
         next_obj = obj

--- a/textx/scoping/tools.py
+++ b/textx/scoping/tools.py
@@ -86,7 +86,7 @@ def get_list_of_concatenated_objects(def_obj, path_to_extension):
                 def_objs.append(o)
             for o in obj_or_list:
                 if type(o) is not Postponed:
-                    rec_walk(resolved_model_path(o, path_to_extension))
+                    rec_walk(resolve_model_path(o, path_to_extension))
 
     rec_walk(def_obj)
     return def_objs
@@ -148,20 +148,24 @@ def get_named_obj_in_list(obj_list, name):
         return None
 
 
-def resolved_model_path(obj, dot_separated_name,
-                        follow_named_element_in_lists=False):
+def resolve_model_path(obj, dot_separated_name,
+                       follow_named_element_in_lists=False):
     """
     Get a model object based on a model-path starting from some
     model object. It can be used in the same way you would
     navigate through a normal instance of a model object, except:
      - "parent(TYPE)" can be used to navigate to the parent of an
-       element, until a certain type is reached (see unittest).
+       element repeatedly, until a certain type is reached (see
+       unittest).
      - lists of named objects (e.g. lists of named packages) can be
        traversed, as if the named objects were part of the model
        grammar (see unittest: Syntax,
        "name_of_model_list.name_of_named_obj_in_list").
      - None/Postponed values are intercepted and lead to an overall
        return value None/Postponed.
+    A use case for this function is, when a model path needs to be
+    stored and executed on a previously unknown object and/or the
+    Postpone/None-logic is required.
 
     Args:
         obj: the current object
@@ -197,8 +201,8 @@ def resolved_model_path(obj, dot_separated_name,
         if type(next_obj) is Postponed:
             return next_obj
         elif next_obj is not None:
-            return resolved_model_path(next_obj, ".".join(names[1:]),
-                                       follow_named_element_in_lists)
+            return resolve_model_path(next_obj, ".".join(names[1:]),
+                                      follow_named_element_in_lists)
         else:
             return None
     else:
@@ -208,7 +212,7 @@ def resolved_model_path(obj, dot_separated_name,
         elif next_obj is None:
             return None
     if len(names) > 1:
-        return resolved_model_path(next_obj, ".".join(
+        return resolve_model_path(next_obj, ".".join(
             names[1:]), follow_named_element_in_lists)
     return next_obj
 


### PR DESCRIPTION
<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [x] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`).


[commit messages]: https://chris.beams.io/posts/git-commit/

 * **Goal**: "Refactor" local scope providers to make implementation and API clearer.
 * **Problem:** `RelativeName` and `ExtRelativeName` are difficult to explain.
 * **Solution:** refactored both scope providers and some internal functions in textx.scoping.tools.py. 
   * Made implementation more reabale:
       * textx.scoping.providers.RelativeName.get_reference_propositions
       * textx.scoping.providers.ExtRelativeName.get_reference_propositions (here, we have much clarity gained!)
   * Especially one accidentally included feature made the code very difficult to understand: When traversing the model with a "model-path", lists were interpreted as list of named-objects. This is not needed by all examples given.
   *  Thus, it is not a 100% refactoring, since we do not allow to have lists within
a path to a desired object (but this was never used in any example). It is
not very probable that this breaks existing code (the old behavior can reactivated with the parameter 'follow_named_element_in_lists' in tools.py with minor differences for postponed references).