### PR TITLE
fix of issue 196: exception safety (obj processors do not report validation errors when reloading some models):

### DIFF
--- a/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_IMPORT_ERROR.eflow
+++ b/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_IMPORT_ERROR.eflow
@@ -1,0 +1,6 @@
+#include "data_structures_including_error.edata"   // <--- types must be lowercase
+#include "types.etype"
+
+algo A1 : Point -> City
+algo A2 : City -> Population
+connect A1 -> A2

--- a/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_IMPORT_SYNTAX_ERROR.eflow
+++ b/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_IMPORT_SYNTAX_ERROR.eflow
@@ -1,0 +1,6 @@
+#include "data_structures.edata"
+#include "types_with_syntax_error.etype"
+
+algo A1 : Point -> City
+algo A2 : City -> Population
+connect A1 -> A2

--- a/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_SYNTAX_ERROR.eflow
+++ b/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_SYNTAX_ERROR.eflow
@@ -1,0 +1,6 @@
+UNEXPECTED_#include "data_structures_including_error.edata"
+#include "types.etype"
+
+algo A1 : Point -> City
+algo A2 : City -> Population
+connect A1 -> A                                     // <--- Unknown object "A" of class "Algo"

--- a/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_TYPE_ERROR.eflow
+++ b/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_TYPE_ERROR.eflow
@@ -1,0 +1,6 @@
+#include "data_structures_including_error.edata"
+#include "types.etype"
+
+algo A1 : Point -> City
+algo A2 : City -> Population
+connect A1 -> A                                     // <--- Unknown object "A" of class "Algo"

--- a/tests/functional/registration/projects/flow_dsl/tests/models/types_with_syntax_error.etype
+++ b/tests/functional/registration/projects/flow_dsl/tests/models/types_with_syntax_error.etype
@@ -1,0 +1,2 @@
+UNEXPECTED_type Int // Syntax error
+type string

--- a/tests/functional/registration/projects/flow_dsl/tests/test_flow_dsl.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_flow_dsl.py
@@ -46,7 +46,21 @@ def test_flow_dsl_types_validation(clear_all):
     Test flow model including error raises error.
     """
 
+    # print("-----------------------------------1---")
+    # print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+    # print("----------------- #={}".format(
+    #    len(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())))
     mmF = metamodel_for_language('flow-dsl')
+    with pytest.raises(TextXSyntaxError,
+                       match=r'.*lowercase.*'):
+        mmF.model_from_file(os.path.join(current_dir,
+                                         'models',
+                                         'data_flow_including_error.eflow'))
+
+    # print("-----------------------------------2---")
+    # print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+    # print("----------------- #={}".format(
+    #    len(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())))
     with pytest.raises(TextXSyntaxError,
                        match=r'.*lowercase.*'):
         mmF.model_from_file(os.path.join(current_dir,

--- a/tests/functional/registration/projects/flow_dsl/tests/test_flow_dsl.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_flow_dsl.py
@@ -57,6 +57,8 @@ def test_flow_dsl_types_validation(clear_all):
                                          'models',
                                          'data_flow_including_error.eflow'))
 
+    # When reading a second time, the error must be reported again:
+
     # print("-----------------------------------2---")
     # print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
     # print("----------------- #={}".format(

--- a/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
@@ -61,7 +61,6 @@ def test_issue196_errors_in_scope_provider_and_obj_processor():
         _tx_model_repository.all_models.filename_to_model.keys())
 
 
-
 def test_issue196_syntax_error_1():
     mmF = metamodel_for_language('flow-dsl')
 
@@ -75,9 +74,10 @@ def test_issue196_syntax_error_1():
 
     with pytest.raises(TextXError,
                        match=r'.*error: Expected.*'):
-        mmF.model_from_file(os.path.join(current_dir,
-                                         'models',
-                                         'MODEL_WITH_IMPORT_SYNTAX_ERROR.eflow'))
+        mmF.model_from_file(
+            os.path.join(current_dir,
+                         'models',
+                         'MODEL_WITH_IMPORT_SYNTAX_ERROR.eflow'))
 
     # print("-----------------------------------2---")
     # print(metamodel_for_language('flow-dsl').

--- a/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
@@ -10,12 +10,13 @@ current_dir = os.path.dirname(__file__)
 def test_issue196_example():
     mmF = metamodel_for_language('flow-dsl')
 
-    print("-----------------------------------1---")
-    print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+    # print("-----------------------------------1---")
+    # print(metamodel_for_language('flow-dsl').
+    #      _tx_model_repository.all_models.filename_to_model.keys())
 
     cached_model_count = len(
         metamodel_for_language('flow-dsl').
-            _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model.keys())
 
     with pytest.raises(TextXError,
                        match=r'.*types must be lowercase.*'):
@@ -23,13 +24,14 @@ def test_issue196_example():
                                          'models',
                                          'MODEL_WITH_IMPORT_ERROR.eflow'))
 
-    print("-----------------------------------2---")
-    print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+    # print("-----------------------------------2---")
+    # print(metamodel_for_language('flow-dsl').
+    #      _tx_model_repository.all_models.filename_to_model.keys())
 
     # error while reading, no file cached!
     assert cached_model_count == len(
         metamodel_for_language('flow-dsl').
-            _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model.keys())
 
     with pytest.raises(TextXError,
                        match=r'.*Unknown object "A" of class "Algo".*'):
@@ -38,13 +40,14 @@ def test_issue196_example():
                                          'models',
                                          'MODEL_WITH_TYPE_ERROR.eflow'))
 
-    print("-----------------------------------3---")
-    print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+    # print("-----------------------------------3---")
+    # print(metamodel_for_language('flow-dsl').
+    #      _tx_model_repository.all_models.filename_to_model.keys())
 
     # error while reading, no file cached!
     assert cached_model_count == len(
         metamodel_for_language('flow-dsl').
-            _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model.keys())
 
     with pytest.raises(TextXError,
                        match=r'.*types must be lowercase.*'):
@@ -55,4 +58,4 @@ def test_issue196_example():
     # error while reading, no file cached!
     assert cached_model_count == len(
         metamodel_for_language('flow-dsl').
-            _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model.keys())

--- a/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
@@ -1,0 +1,57 @@
+from textx import metamodel_for_language
+from textx.exceptions import TextXError
+import os.path
+import pytest
+
+
+current_dir = os.path.dirname(__file__)
+
+
+def test_flow():
+    mmF = metamodel_for_language('flow-dsl')
+
+    print("-----------------------------------1---")
+    print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+
+    cached_model_count = len(
+        metamodel_for_language('flow-dsl').
+            _tx_model_repository.all_models.filename_to_model.keys())
+
+    with pytest.raises(TextXError,
+                       match=r'.*types must be lowercase.*'):
+        mmF.model_from_file(os.path.join(current_dir,
+                                         'models',
+                                         'MODEL_WITH_IMPORT_ERROR.eflow'))
+
+    print("-----------------------------------2---")
+    print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+
+    # error while reading, no file cached!
+    assert cached_model_count == len(
+        metamodel_for_language('flow-dsl').
+            _tx_model_repository.all_models.filename_to_model.keys())
+
+    with pytest.raises(TextXError,
+                       match=r'.*Unknown object "A" of class "Algo".*'):
+        mmF.model_from_file(os.path.join(current_dir,
+                                         'models',
+                                         'MODEL_WITH_TYPE_ERROR.eflow'))
+
+    print("-----------------------------------3---")
+    print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+
+    # error while reading, no file cached!
+    assert cached_model_count == len(
+        metamodel_for_language('flow-dsl').
+            _tx_model_repository.all_models.filename_to_model.keys())
+
+    with pytest.raises(TextXError,
+                       match=r'.*types must be lowercase.*'):
+        mmF.model_from_file(os.path.join(current_dir,
+                                         'models',
+                                         'MODEL_WITH_IMPORT_ERROR.eflow'))
+
+    # error while reading, no file cached!
+    assert cached_model_count == len(
+        metamodel_for_language('flow-dsl').
+            _tx_model_repository.all_models.filename_to_model.keys())

--- a/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
@@ -7,7 +7,7 @@ import pytest
 current_dir = os.path.dirname(__file__)
 
 
-def test_issue196_example():
+def test_issue196_errors_in_scope_provider_and_obj_processor():
     mmF = metamodel_for_language('flow-dsl')
 
     # print("-----------------------------------1---")
@@ -54,6 +54,61 @@ def test_issue196_example():
         mmF.model_from_file(os.path.join(current_dir,
                                          'models',
                                          'MODEL_WITH_IMPORT_ERROR.eflow'))
+
+    # error while reading, no file cached!
+    assert cached_model_count == len(
+        metamodel_for_language('flow-dsl').
+        _tx_model_repository.all_models.filename_to_model.keys())
+
+
+
+def test_issue196_syntax_error_1():
+    mmF = metamodel_for_language('flow-dsl')
+
+    # print("-----------------------------------1---")
+    # print(metamodel_for_language('flow-dsl').
+    #      _tx_model_repository.all_models.filename_to_model.keys())
+
+    cached_model_count = len(
+        metamodel_for_language('flow-dsl').
+        _tx_model_repository.all_models.filename_to_model.keys())
+
+    with pytest.raises(TextXError,
+                       match=r'.*error: Expected.*'):
+        mmF.model_from_file(os.path.join(current_dir,
+                                         'models',
+                                         'MODEL_WITH_IMPORT_SYNTAX_ERROR.eflow'))
+
+    # print("-----------------------------------2---")
+    # print(metamodel_for_language('flow-dsl').
+    #      _tx_model_repository.all_models.filename_to_model.keys())
+
+    # error while reading, no file cached!
+    assert cached_model_count == len(
+        metamodel_for_language('flow-dsl').
+        _tx_model_repository.all_models.filename_to_model.keys())
+
+
+def test_issue196_syntax_error_2():
+    mmF = metamodel_for_language('flow-dsl')
+
+    # print("-----------------------------------1---")
+    # print(metamodel_for_language('flow-dsl').
+    #      _tx_model_repository.all_models.filename_to_model.keys())
+
+    cached_model_count = len(
+        metamodel_for_language('flow-dsl').
+        _tx_model_repository.all_models.filename_to_model.keys())
+
+    with pytest.raises(TextXError,
+                       match=r'.*error: Expected.*'):
+        mmF.model_from_file(os.path.join(current_dir,
+                                         'models',
+                                         'MODEL_WITH_SYNTAX_ERROR.eflow'))
+
+    # print("-----------------------------------2---")
+    # print(metamodel_for_language('flow-dsl').
+    #      _tx_model_repository.all_models.filename_to_model.keys())
 
     # error while reading, no file cached!
     assert cached_model_count == len(

--- a/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
@@ -7,7 +7,7 @@ import pytest
 current_dir = os.path.dirname(__file__)
 
 
-def test_flow():
+def test_issue196_example():
     mmF = metamodel_for_language('flow-dsl')
 
     print("-----------------------------------1---")
@@ -33,6 +33,7 @@ def test_flow():
 
     with pytest.raises(TextXError,
                        match=r'.*Unknown object "A" of class "Algo".*'):
+        print("loading MODEL_WITH_TYPE_ERROR")
         mmF.model_from_file(os.path.join(current_dir,
                                          'models',
                                          'MODEL_WITH_TYPE_ERROR.eflow'))

--- a/textx/metamodel.py
+++ b/textx/metamodel.py
@@ -586,7 +586,7 @@ class TextXMetaModel(DebugPrinter):
                     from textx.scoping import GlobalModelRepository
                     filename = other_model._tx_filename
                     assert filename
-                    # print("METAMODEL PRE-CALLBACK{}".format(filename))
+                    # print("METAMODEL PRE-CALLBACK => {}".format(filename))
                     other_model._tx_model_repository = GlobalModelRepository(
                         self._tx_model_repository.all_models)
                     self._tx_model_repository.all_models\

--- a/textx/model.py
+++ b/textx/model.py
@@ -650,7 +650,8 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                             in m._tx_reference_resolver.delayed_crossrefs:
                         line, col = parser.pos_to_linecol(delayed.position)
                         error_text += ' "{}" of class "{}" at {}'.format(
-                            delayed.obj_name, delayed.cls.__name__, (line, col))
+                            delayed.obj_name, delayed.cls.__name__, (
+                                line, col))
                 raise TextXSemanticError(error_text, line=line, col=col)
 
             for m in models:

--- a/textx/model.py
+++ b/textx/model.py
@@ -668,7 +668,8 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
 
                 # final check that everything went ok
                 for m in models:
-                    assert 0 == len(get_children_of_type(Postponed.__class__, m))
+                    assert 0 == len(get_children_of_type(
+                        Postponed.__class__, m))
 
                     # We have model loaded and all link resolved
                     # So we shall do a depth-first call of object
@@ -685,7 +686,8 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                 for m in models:
                     for m2 in models:
                         if hasattr(m2._tx_metamodel, "_tx_model_repository"):
-                            m2._tx_metamodel._tx_model_repository.remove_model(m)
+                            m2._tx_metamodel.\
+                                _tx_model_repository.remove_model(m)
                         if hasattr(m2, "_tx_model_repository"):
                             m2._tx_model_repository.remove_model(m)
                 raise e
@@ -697,8 +699,8 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
             # (required for binary search)
             model._pos_crossref_list = pos_crossref_list
 
-            # Dict for storing rules where key is position of rule instance in text
-            # Sorted based on nested rules
+            # Dict for storing rules where key is position of rule instance in
+            # text. Sorted based on nested rules.
             model._pos_rule_dict = OrderedDict(sorted(pos_rule_dict.items(),
                                                       key=lambda x: x[0],
                                                       reverse=True))
@@ -707,13 +709,15 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
         # remove all models beeing constructed
         from textx.scoping import get_all_models_including_attached_models
         models = get_all_models_including_attached_models(model)
-        for m in filter(lambda x:hasattr(x,"_tx_reference_resolver"), models):
+        for m in filter(
+                lambda x: hasattr(x, "_tx_reference_resolver"), models):
             for m2 in models:
                 if hasattr(m2._tx_metamodel, "_tx_model_repository"):
                     m2._tx_metamodel._tx_model_repository.remove_model(m)
                 if hasattr(m2, "_tx_model_repository"):
                     m2._tx_model_repository.remove_model(m)
-        for m in filter(lambda x:hasattr(x,"_tx_reference_resolver"), models):
+        for m in filter(
+                lambda x: hasattr(x, "_tx_reference_resolver"), models):
             del m._tx_reference_resolver
         raise e
 

--- a/textx/model.py
+++ b/textx/model.py
@@ -624,61 +624,56 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
     if is_main_model:
         from textx.scoping import get_all_models_including_attached_models
         models = get_all_models_including_attached_models(model)
-        # filter out all models w/o resolver:
-        models = list(filter(
-            lambda x: hasattr(x, "_tx_reference_resolver"), models))
+        try:
+            # filter out all models w/o resolver:
+            models = list(filter(
+                lambda x: hasattr(x, "_tx_reference_resolver"), models))
 
-        resolved_count = 1
-        unresolved_count = 1
-        while unresolved_count > 0 and resolved_count > 0:
-            resolved_count = 0
-            unresolved_count = 0
-            # print("***RESOLVING {} models".format(len(models)))
+            resolved_count = 1
+            unresolved_count = 1
+            while unresolved_count > 0 and resolved_count > 0:
+                resolved_count = 0
+                unresolved_count = 0
+                # print("***RESOLVING {} models".format(len(models)))
+                for m in models:
+                    resolved_count_for_this_model, delayed_crossrefs = \
+                        m._tx_reference_resolver.resolve_one_step()
+                    resolved_count += resolved_count_for_this_model
+                    unresolved_count += len(delayed_crossrefs)
+                # print("DEBUG: delayed #:{} unresolved #:{}".
+                #      format(unresolved_count,unresolved_count))
+            if (unresolved_count > 0):
+                error_text = "Unresolvable cross references:"
+
+                for m in models:
+                    for _, _, delayed \
+                            in m._tx_reference_resolver.delayed_crossrefs:
+                        line, col = parser.pos_to_linecol(delayed.position)
+                        error_text += ' "{}" of class "{}" at {}'.format(
+                            delayed.obj_name, delayed.cls.__name__, (line, col))
+                raise TextXSemanticError(error_text, line=line, col=col)
+
             for m in models:
-                resolved_count_for_this_model, delayed_crossrefs = \
-                    m._tx_reference_resolver.resolve_one_step()
-                resolved_count += resolved_count_for_this_model
-                unresolved_count += len(delayed_crossrefs)
-            # print("DEBUG: delayed #:{} unresolved #:{}".
-            #      format(unresolved_count,unresolved_count))
-        if (unresolved_count > 0):
-            error_text = "Unresolvable cross references:"
+                # TODO: what does this check?
+                assert not m._tx_reference_resolver.parser._inst_stack
 
+            # cleanup
             for m in models:
-                for _, _, delayed \
-                        in m._tx_reference_resolver.delayed_crossrefs:
-                    line, col = parser.pos_to_linecol(delayed.position)
-                    error_text += ' "{}" of class "{}" at {}'.format(
-                        delayed.obj_name, delayed.cls.__name__, (line, col))
-            raise TextXSemanticError(error_text, line=line, col=col)
+                del m._tx_reference_resolver
 
-        for m in models:
-            # TODO: what does this check?
-            assert not m._tx_reference_resolver.parser._inst_stack
+            # final check that everything went ok
+            for m in models:
+                assert 0 == len(get_children_of_type(Postponed.__class__, m))
 
-        # cleanup
-        for m in models:
-            del m._tx_reference_resolver
-
-        # final check that everything went ok
-        first_error = None
-        for m in models:
-            assert 0 == len(get_children_of_type(Postponed.__class__, m))
-
-            # We have model loaded and all link resolved
-            # So we shall do a depth-first call of object
-            # processors if any processor is defined.
-            if m._tx_metamodel.obj_processors:
-                if parser.debug:
-                    parser.dprint("CALLING OBJECT PROCESSORS")
-                try:
+                # We have model loaded and all link resolved
+                # So we shall do a depth-first call of object
+                # processors if any processor is defined.
+                if m._tx_metamodel.obj_processors:
+                    if parser.debug:
+                        parser.dprint("CALLING OBJECT PROCESSORS")
                     call_obj_processors(m._tx_metamodel, m)
-                except BaseException as e:
-                    # print("OBJ PROCESSOR ERROR {}".format(str(e)))
-                    if first_error is None:
-                        first_error = e
 
-        if first_error is not None:
+        except BaseException as e:
             # remove all processed models from (global) repo (if present)
             # (remove all of them, not only the model with errors,
             # since, models with errors may be included in other models)
@@ -688,7 +683,7 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                         m2._tx_metamodel._tx_model_repository.remove_model(m)
                     if hasattr(m2, "_tx_model_repository"):
                         m2._tx_model_repository.remove_model(m)
-            raise first_error
+            raise e
 
     if metamodel.textx_tools_support \
             and type(model) not in PRIMITIVE_PYTHON_TYPES:

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -46,6 +46,15 @@ class ModelRepository(object):
     def has_model(self, filename):
         return filename in self.filename_to_model
 
+    def remove_model(self, model):
+        filename = None
+        for f, m in self.filename_to_model.items():
+            if m == model:
+                filename = f
+        if filename:
+            # print("*** delete {}".format(filename))
+            del self.filename_to_model[filename]
+
 
 class GlobalModelRepository(object):
     """
@@ -81,6 +90,10 @@ class GlobalModelRepository(object):
             self.all_models = all_models  # used to reuse already loaded models
         else:
             self.all_models = ModelRepository()
+
+    def remove_model(self, model):
+        self.all_models.remove_model(model)
+        self.local_models.remove_model(model)
 
     def load_models_using_filepattern(
             self, filename_pattern, model, glob_args, is_main_model=False,
@@ -170,6 +183,7 @@ class GlobalModelRepository(object):
 
         if not self.local_models.has_model(filename):
             if self.all_models.has_model(filename):
+                # print("CACHED {}".format(filename))
                 new_model = self.all_models.filename_to_model[filename]
             else:
                 # print("LOADING {}".format(filename))
@@ -183,11 +197,16 @@ class GlobalModelRepository(object):
             # print("ADDING {}".format(filename))
             if add_to_local_models:
                 self.local_models.filename_to_model[filename] = new_model
+        else:
+            # print("LOCALLY CACHED {}".format(filename))
+            pass
+
         assert self.all_models.has_model(filename)  # to be sure...
         return self.all_models.filename_to_model[filename]
 
     def _add_model(self, model):
         filename = self.update_model_in_repo_based_on_filename(model)
+        # print("ADDED {}".format(filename))
         self.local_models.filename_to_model[filename] = model
 
     def update_model_in_repo_based_on_filename(self, model):
@@ -204,6 +223,7 @@ class GlobalModelRepository(object):
         if model._tx_filename is None:
             for fn in self.all_models.filename_to_model:
                 if self.all_models.filename_to_model[fn] == model:
+                    # print("UPDATED/CACHED {}".format(fn))
                     return fn
             i = 0
             while self.all_models.has_model("anonymous{}".format(i)):
@@ -214,6 +234,7 @@ class GlobalModelRepository(object):
             myfilename = model._tx_filename
             if (not self.all_models.has_model(myfilename)):
                 self.all_models.filename_to_model[myfilename] = model
+        # print("UPDATED/ADDED/CACHED {}".format(myfilename))
         return myfilename
 
     def pre_ref_resolution_callback(self, other_model):
@@ -226,8 +247,8 @@ class GlobalModelRepository(object):
         Returns:
             nothing
         """
-        # print("PRE-CALLBACK{}".format(filename))
         filename = other_model._tx_filename
+        # print("PRE-CALLBACK -> {}".format(filename))
         assert (filename)
         other_model._tx_model_repository = \
             GlobalModelRepository(self.all_models)

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -52,7 +52,7 @@ class ModelRepository(object):
             if m == model:
                 filename = f
         if filename:
-            print("*** delete {}".format(filename))
+            # print("*** delete {}".format(filename))
             del self.filename_to_model[filename]
 
 

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -52,7 +52,7 @@ class ModelRepository(object):
             if m == model:
                 filename = f
         if filename:
-            # print("*** delete {}".format(filename))
+            print("*** delete {}".format(filename))
             del self.filename_to_model[filename]
 
 

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -306,7 +306,7 @@ class ImportURI(scoping.ModelLoader):
             add_to_local_models = True
             if self.importURI_to_scope_name is not None:
                 obj.name = self.importURI_to_scope_name(obj)
-                print("setting name to {}".format(obj.name))
+                # print("setting name to {}".format(obj.name))
             if hasattr(obj, "name"):
                 if obj.name is not None and obj.name != "":
                     add_to_local_models = not self.importAs

--- a/textx/scoping/tools.py
+++ b/textx/scoping/tools.py
@@ -239,7 +239,7 @@ def get_unique_named_object_in_all_models(root, name):
 
     a = []
     for m in src:
-        print("analyzing {}".format(m._tx_filename))
+        # print("analyzing {}".format(m._tx_filename))
         a = a + get_children(
             lambda x: hasattr(x, 'name') and x.name == name, m)
 


### PR DESCRIPTION
 * Problem was, that **with a global repository in the metamodel**, that **models with errors were cached** and reused (w/o beeing checked). Related docs: http://textx.github.io/textX/stable/scoping/#note-on-uniqueness-of-model-elements-global-repository
 * Solution: **delete all models touched while loading a model, when an error occurs** in object processors (in all repositories). - - > **strong exception safety guarantee**. 
 * _Alternative (not implemented)_: re-check cached models (Problem: what happens if the object processor modifies the model? Not good running object processors twice)
 * Minor: added (commented) printfs and commented some old printfs found in the codebase.

In principle this is a BIC. However, the previous behavior is a bug in my eyes... @igordejanovic: How to proceed?

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated (**used testcase sketched in #196**, thank you @danixeee )
- [x] Docstrings have been included and/or updated, as appropriate **N/A**
- [x] Standalone docs have been updated accordingly **N/A??**
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`).


[commit messages]: https://chris.beams.io/posts/git-commit/
