### PR TITLE
issue196 exception safety, rebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,15 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Added
 
-  - Added new function `textx.scoping.is_file_included` [#197]
+  - Added new function `textx.scoping.is_file_included` ([#197]).
 
 ### Changed
 
   - Changed function name `textx.scoping.get_all_models_including_attached_models`
-    to `textx.scoping.get_included_models` [#197] (marked old function
-    as deprecated).
+    to `textx.scoping.get_included_models` (marked old function
+    as deprecated) ([#197]).
   - Delete all models touched while loading a model, when an error occurs 
-    while loading in all repositories (strong exception safety guarantee). [#200]
+    while loading in all repositories (strong exception safety guarantee) ([#200]).
 
 ## [v2.0.1] (released: 2019-05-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -409,6 +409,8 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#200]: https://github.com/textX/textX/issues/200
+[#197]: https://github.com/textX/textX/issues/197
 [#188]: https://github.com/textX/textX/issues/188
 [#187]: https://github.com/textX/textX/pull/187
 [#186]: https://github.com/textX/textX/pull/186

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ please take a look at related PRs and issues and see if the change affects you.
   - Changed function name `textx.scoping.get_all_models_including_attached_models`
     to `textx.scoping.get_included_models` [#197] (marked old function
     as deprecated).
+  - Delete all models touched while loading a model, when an error occurs 
+    while loading in all repositories (strong exception safety guarantee). [#200]
 
 ## [v2.0.1] (released: 2019-05-20)
 

--- a/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_IMPORT_ERROR.eflow
+++ b/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_IMPORT_ERROR.eflow
@@ -1,0 +1,6 @@
+#include "data_structures_including_error.edata"   // <--- types must be lowercase
+#include "types.etype"
+
+algo A1 : Point -> City
+algo A2 : City -> Population
+connect A1 -> A2

--- a/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_IMPORT_SYNTAX_ERROR.eflow
+++ b/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_IMPORT_SYNTAX_ERROR.eflow
@@ -1,0 +1,6 @@
+#include "data_structures.edata"
+#include "types_with_syntax_error.etype"
+
+algo A1 : Point -> City
+algo A2 : City -> Population
+connect A1 -> A2

--- a/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_SYNTAX_ERROR.eflow
+++ b/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_SYNTAX_ERROR.eflow
@@ -1,0 +1,6 @@
+UNEXPECTED_#include "data_structures_including_error.edata"
+#include "types.etype"
+
+algo A1 : Point -> City
+algo A2 : City -> Population
+connect A1 -> A                                     // <--- Unknown object "A" of class "Algo"

--- a/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_TYPE_ERROR.eflow
+++ b/tests/functional/registration/projects/flow_dsl/tests/models/MODEL_WITH_TYPE_ERROR.eflow
@@ -1,0 +1,6 @@
+#include "data_structures_including_error.edata"
+#include "types.etype"
+
+algo A1 : Point -> City
+algo A2 : City -> Population
+connect A1 -> A                                     // <--- Unknown object "A" of class "Algo"

--- a/tests/functional/registration/projects/flow_dsl/tests/models/types_with_syntax_error.etype
+++ b/tests/functional/registration/projects/flow_dsl/tests/models/types_with_syntax_error.etype
@@ -1,0 +1,2 @@
+UNEXPECTED_type Int // Syntax error
+type string

--- a/tests/functional/registration/projects/flow_dsl/tests/test_flow_dsl.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_flow_dsl.py
@@ -46,7 +46,21 @@ def test_flow_dsl_types_validation(clear_all):
     Test flow model including error raises error.
     """
 
+    # print("-----------------------------------1---")
+    # print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+    # print("----------------- #={}".format(
+    #    len(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())))
     mmF = metamodel_for_language('flow-dsl')
+    with pytest.raises(TextXSyntaxError,
+                       match=r'.*lowercase.*'):
+        mmF.model_from_file(os.path.join(current_dir,
+                                         'models',
+                                         'data_flow_including_error.eflow'))
+
+    # print("-----------------------------------2---")
+    # print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+    # print("----------------- #={}".format(
+    #    len(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())))
     with pytest.raises(TextXSyntaxError,
                        match=r'.*lowercase.*'):
         mmF.model_from_file(os.path.join(current_dir,

--- a/tests/functional/registration/projects/flow_dsl/tests/test_flow_dsl.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_flow_dsl.py
@@ -57,6 +57,8 @@ def test_flow_dsl_types_validation(clear_all):
                                          'models',
                                          'data_flow_including_error.eflow'))
 
+    # When reading a second time, the error must be reported again:
+
     # print("-----------------------------------2---")
     # print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
     # print("----------------- #={}".format(

--- a/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
@@ -61,7 +61,6 @@ def test_issue196_errors_in_scope_provider_and_obj_processor():
         _tx_model_repository.all_models.filename_to_model.keys())
 
 
-
 def test_issue196_syntax_error_1():
     mmF = metamodel_for_language('flow-dsl')
 
@@ -75,9 +74,10 @@ def test_issue196_syntax_error_1():
 
     with pytest.raises(TextXError,
                        match=r'.*error: Expected.*'):
-        mmF.model_from_file(os.path.join(current_dir,
-                                         'models',
-                                         'MODEL_WITH_IMPORT_SYNTAX_ERROR.eflow'))
+        mmF.model_from_file(
+            os.path.join(current_dir,
+                         'models',
+                         'MODEL_WITH_IMPORT_SYNTAX_ERROR.eflow'))
 
     # print("-----------------------------------2---")
     # print(metamodel_for_language('flow-dsl').

--- a/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
@@ -10,12 +10,13 @@ current_dir = os.path.dirname(__file__)
 def test_issue196_example():
     mmF = metamodel_for_language('flow-dsl')
 
-    print("-----------------------------------1---")
-    print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+    # print("-----------------------------------1---")
+    # print(metamodel_for_language('flow-dsl').
+    #      _tx_model_repository.all_models.filename_to_model.keys())
 
     cached_model_count = len(
         metamodel_for_language('flow-dsl').
-            _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model.keys())
 
     with pytest.raises(TextXError,
                        match=r'.*types must be lowercase.*'):
@@ -23,13 +24,14 @@ def test_issue196_example():
                                          'models',
                                          'MODEL_WITH_IMPORT_ERROR.eflow'))
 
-    print("-----------------------------------2---")
-    print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+    # print("-----------------------------------2---")
+    # print(metamodel_for_language('flow-dsl').
+    #      _tx_model_repository.all_models.filename_to_model.keys())
 
     # error while reading, no file cached!
     assert cached_model_count == len(
         metamodel_for_language('flow-dsl').
-            _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model.keys())
 
     with pytest.raises(TextXError,
                        match=r'.*Unknown object "A" of class "Algo".*'):
@@ -38,13 +40,14 @@ def test_issue196_example():
                                          'models',
                                          'MODEL_WITH_TYPE_ERROR.eflow'))
 
-    print("-----------------------------------3---")
-    print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+    # print("-----------------------------------3---")
+    # print(metamodel_for_language('flow-dsl').
+    #      _tx_model_repository.all_models.filename_to_model.keys())
 
     # error while reading, no file cached!
     assert cached_model_count == len(
         metamodel_for_language('flow-dsl').
-            _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model.keys())
 
     with pytest.raises(TextXError,
                        match=r'.*types must be lowercase.*'):
@@ -55,4 +58,4 @@ def test_issue196_example():
     # error while reading, no file cached!
     assert cached_model_count == len(
         metamodel_for_language('flow-dsl').
-            _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model.keys())

--- a/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
@@ -1,0 +1,57 @@
+from textx import metamodel_for_language
+from textx.exceptions import TextXError
+import os.path
+import pytest
+
+
+current_dir = os.path.dirname(__file__)
+
+
+def test_flow():
+    mmF = metamodel_for_language('flow-dsl')
+
+    print("-----------------------------------1---")
+    print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+
+    cached_model_count = len(
+        metamodel_for_language('flow-dsl').
+            _tx_model_repository.all_models.filename_to_model.keys())
+
+    with pytest.raises(TextXError,
+                       match=r'.*types must be lowercase.*'):
+        mmF.model_from_file(os.path.join(current_dir,
+                                         'models',
+                                         'MODEL_WITH_IMPORT_ERROR.eflow'))
+
+    print("-----------------------------------2---")
+    print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+
+    # error while reading, no file cached!
+    assert cached_model_count == len(
+        metamodel_for_language('flow-dsl').
+            _tx_model_repository.all_models.filename_to_model.keys())
+
+    with pytest.raises(TextXError,
+                       match=r'.*Unknown object "A" of class "Algo".*'):
+        mmF.model_from_file(os.path.join(current_dir,
+                                         'models',
+                                         'MODEL_WITH_TYPE_ERROR.eflow'))
+
+    print("-----------------------------------3---")
+    print(metamodel_for_language('flow-dsl')._tx_model_repository.all_models.filename_to_model.keys())
+
+    # error while reading, no file cached!
+    assert cached_model_count == len(
+        metamodel_for_language('flow-dsl').
+            _tx_model_repository.all_models.filename_to_model.keys())
+
+    with pytest.raises(TextXError,
+                       match=r'.*types must be lowercase.*'):
+        mmF.model_from_file(os.path.join(current_dir,
+                                         'models',
+                                         'MODEL_WITH_IMPORT_ERROR.eflow'))
+
+    # error while reading, no file cached!
+    assert cached_model_count == len(
+        metamodel_for_language('flow-dsl').
+            _tx_model_repository.all_models.filename_to_model.keys())

--- a/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
@@ -16,7 +16,7 @@ def test_issue196_errors_in_scope_provider_and_obj_processor():
 
     cached_model_count = len(
         metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model)
 
     with pytest.raises(TextXError,
                        match=r'.*types must be lowercase.*'):
@@ -31,7 +31,7 @@ def test_issue196_errors_in_scope_provider_and_obj_processor():
     # error while reading, no file cached (cached_model_count unchanged)!
     assert cached_model_count == len(
         metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model)
 
     with pytest.raises(TextXError,
                        match=r'.*Unknown object "A" of class "Algo".*'):
@@ -44,10 +44,10 @@ def test_issue196_errors_in_scope_provider_and_obj_processor():
     # print(metamodel_for_language('flow-dsl').
     #      _tx_model_repository.all_models.filename_to_model.keys())
 
-    # error while reading, no file cached!
+    # error while reading, no file cached! (cached_model_count unchanged)!
     assert cached_model_count == len(
         metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model)
 
     with pytest.raises(TextXError,
                        match=r'.*types must be lowercase.*'):
@@ -55,10 +55,10 @@ def test_issue196_errors_in_scope_provider_and_obj_processor():
                                          'models',
                                          'MODEL_WITH_IMPORT_ERROR.eflow'))
 
-    # error while reading, no file cached!
+    # error while reading, no file cached! (cached_model_count unchanged)!
     assert cached_model_count == len(
         metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model)
 
 
 def test_issue196_syntax_error_1():
@@ -70,7 +70,7 @@ def test_issue196_syntax_error_1():
 
     cached_model_count = len(
         metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model)
 
     with pytest.raises(TextXError,
                        match=r'.*error: Expected.*'):
@@ -86,7 +86,7 @@ def test_issue196_syntax_error_1():
     # error while reading, no file cached!
     assert cached_model_count == len(
         metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model)
 
 
 def test_issue196_syntax_error_2():
@@ -98,7 +98,7 @@ def test_issue196_syntax_error_2():
 
     cached_model_count = len(
         metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model)
 
     with pytest.raises(TextXError,
                        match=r'.*error: Expected.*'):
@@ -110,7 +110,7 @@ def test_issue196_syntax_error_2():
     # print(metamodel_for_language('flow-dsl').
     #      _tx_model_repository.all_models.filename_to_model.keys())
 
-    # error while reading, no file cached!
+    # error while reading, no file cached! (cached_model_count unchanged)!
     assert cached_model_count == len(
         metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model.keys())
+        _tx_model_repository.all_models.filename_to_model)

--- a/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
@@ -7,7 +7,7 @@ import pytest
 current_dir = os.path.dirname(__file__)
 
 
-def test_issue196_example():
+def test_issue196_errors_in_scope_provider_and_obj_processor():
     mmF = metamodel_for_language('flow-dsl')
 
     # print("-----------------------------------1---")
@@ -54,6 +54,61 @@ def test_issue196_example():
         mmF.model_from_file(os.path.join(current_dir,
                                          'models',
                                          'MODEL_WITH_IMPORT_ERROR.eflow'))
+
+    # error while reading, no file cached!
+    assert cached_model_count == len(
+        metamodel_for_language('flow-dsl').
+        _tx_model_repository.all_models.filename_to_model.keys())
+
+
+
+def test_issue196_syntax_error_1():
+    mmF = metamodel_for_language('flow-dsl')
+
+    # print("-----------------------------------1---")
+    # print(metamodel_for_language('flow-dsl').
+    #      _tx_model_repository.all_models.filename_to_model.keys())
+
+    cached_model_count = len(
+        metamodel_for_language('flow-dsl').
+        _tx_model_repository.all_models.filename_to_model.keys())
+
+    with pytest.raises(TextXError,
+                       match=r'.*error: Expected.*'):
+        mmF.model_from_file(os.path.join(current_dir,
+                                         'models',
+                                         'MODEL_WITH_IMPORT_SYNTAX_ERROR.eflow'))
+
+    # print("-----------------------------------2---")
+    # print(metamodel_for_language('flow-dsl').
+    #      _tx_model_repository.all_models.filename_to_model.keys())
+
+    # error while reading, no file cached!
+    assert cached_model_count == len(
+        metamodel_for_language('flow-dsl').
+        _tx_model_repository.all_models.filename_to_model.keys())
+
+
+def test_issue196_syntax_error_2():
+    mmF = metamodel_for_language('flow-dsl')
+
+    # print("-----------------------------------1---")
+    # print(metamodel_for_language('flow-dsl').
+    #      _tx_model_repository.all_models.filename_to_model.keys())
+
+    cached_model_count = len(
+        metamodel_for_language('flow-dsl').
+        _tx_model_repository.all_models.filename_to_model.keys())
+
+    with pytest.raises(TextXError,
+                       match=r'.*error: Expected.*'):
+        mmF.model_from_file(os.path.join(current_dir,
+                                         'models',
+                                         'MODEL_WITH_SYNTAX_ERROR.eflow'))
+
+    # print("-----------------------------------2---")
+    # print(metamodel_for_language('flow-dsl').
+    #      _tx_model_repository.all_models.filename_to_model.keys())
 
     # error while reading, no file cached!
     assert cached_model_count == len(

--- a/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
@@ -7,7 +7,7 @@ import pytest
 current_dir = os.path.dirname(__file__)
 
 
-def test_flow():
+def test_issue196_example():
     mmF = metamodel_for_language('flow-dsl')
 
     print("-----------------------------------1---")
@@ -33,6 +33,7 @@ def test_flow():
 
     with pytest.raises(TextXError,
                        match=r'.*Unknown object "A" of class "Algo".*'):
+        print("loading MODEL_WITH_TYPE_ERROR")
         mmF.model_from_file(os.path.join(current_dir,
                                          'models',
                                          'MODEL_WITH_TYPE_ERROR.eflow'))

--- a/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
@@ -28,7 +28,7 @@ def test_issue196_errors_in_scope_provider_and_obj_processor():
     # print(metamodel_for_language('flow-dsl').
     #      _tx_model_repository.all_models.filename_to_model.keys())
 
-    # error while reading, no file cached!
+    # error while reading, no file cached (cached_model_count unchanged)!
     assert cached_model_count == len(
         metamodel_for_language('flow-dsl').
         _tx_model_repository.all_models.filename_to_model.keys())

--- a/textx/metamodel.py
+++ b/textx/metamodel.py
@@ -586,7 +586,7 @@ class TextXMetaModel(DebugPrinter):
                     from textx.scoping import GlobalModelRepository
                     filename = other_model._tx_filename
                     assert filename
-                    # print("METAMODEL PRE-CALLBACK{}".format(filename))
+                    # print("METAMODEL PRE-CALLBACK => {}".format(filename))
                     other_model._tx_model_repository = GlobalModelRepository(
                         self._tx_model_repository.all_models)
                     self._tx_model_repository.all_models\

--- a/textx/model.py
+++ b/textx/model.py
@@ -713,16 +713,26 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                                                       reverse=True))
     # exception occurred during model creation
     except BaseException as e:
-        # remove all models beeing constructed
-        all_affected_models = get_included_models(model)
-        models_to_be_removed = list(filter(
-                lambda x: hasattr(x, "_tx_reference_resolver"),
-                all_affected_models))
-        for m in all_affected_models:
-            remove_models_from_repositories(m, models_to_be_removed)
+        _remove_all_affected_models_in_construction(model)
         raise e
 
     return model
+
+
+def _remove_all_affected_models_in_construction(model):
+    """
+    Remove all models related to model being constructed
+    from any model repository.
+    This function is private to model.py, since the models
+    being constructed are identified by having a reference
+    resolver (this is an internal design decision of model.py).
+    """
+    all_affected_models = get_included_models(model)
+    models_to_be_removed = list(filter(
+        lambda x: hasattr(x, "_tx_reference_resolver"),
+        all_affected_models))
+    for m in all_affected_models:
+        remove_models_from_repositories(m, models_to_be_removed)
 
 
 class ReferenceResolver:

--- a/textx/model.py
+++ b/textx/model.py
@@ -626,8 +626,8 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
             model._tx_parser = parser
 
         if is_main_model:
-            from textx.scoping import get_all_models_including_attached_models
-            models = get_all_models_including_attached_models(model)
+            from textx.scoping import get_included_models
+            models = get_included_models(model)
             try:
                 # filter out all models w/o resolver:
                 models = list(filter(
@@ -707,8 +707,8 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
     # exception occurred during model creation
     except BaseException as e:
         # remove all models beeing constructed
-        from textx.scoping import get_all_models_including_attached_models
-        models = get_all_models_including_attached_models(model)
+        from textx.scoping import get_included_models
+        models = get_included_models(model)
         for m in filter(
                 lambda x: hasattr(x, "_tx_reference_resolver"), models):
             for m2 in models:

--- a/textx/model.py
+++ b/textx/model.py
@@ -598,14 +598,25 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
         else:
             return return_value_grammar  # may be None
 
+    # load model from file (w/o reference resolution)
+    # Note: if an exception happens here, the model was not yet
+    # added to any repository. Thus, we have no special exception
+    # safety handling at this point...
     model = process_node(parse_tree)
 
+    # Now, the initial version of the model is created.
+    # We catch any exceptions here, to clean up cached models
+    # introduced by, e.g., scope providers. Models will
+    # be marked as "model being constructed" if they represent
+    # a non-trivial model (e.g. are not just a string), see
+    # below ("model being constructed").
     try:
         # Register filename of the model for later use (e.g. imports/scoping).
         is_primitive_type = False
         try:
             model._tx_filename = file_name
-            # mark model as "model being constructed":
+            # mark model as "model being constructed" (see "except"-block
+            # of current "try"-block):
             model._tx_reference_resolver = None
         except AttributeError:
             # model is some primitive python type (e.g. str)

--- a/textx/model.py
+++ b/textx/model.py
@@ -650,7 +650,8 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                             in m._tx_reference_resolver.delayed_crossrefs:
                         line, col = parser.pos_to_linecol(delayed.position)
                         error_text += ' "{}" of class "{}" at {}'.format(
-                            delayed.obj_name, delayed.cls.__name__, (line, col))
+                            delayed.obj_name, delayed.cls.__name__, (
+                                line, col))
                 raise TextXSemanticError(error_text, line=line, col=col)
 
             for m in models:

--- a/textx/model.py
+++ b/textx/model.py
@@ -674,7 +674,7 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
 
                 # cleanup
                 for m in models:
-                    del m._tx_reference_resolver
+                    _end_model_construction(m)
 
                 # final check that everything went ok
                 for m in models:
@@ -725,6 +725,13 @@ def _start_model_construction(model):
     """
     assert not hasattr(model, "_tx_reference_resolver")
     model._tx_reference_resolver = None
+
+
+def _end_model_construction(model):
+    """
+    End model construction (see _start_model_construction).
+    """
+    del model._tx_reference_resolver
 
 
 def _remove_all_affected_models_in_construction(model):

--- a/textx/model.py
+++ b/textx/model.py
@@ -715,9 +715,9 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
     except BaseException as e:
         # remove all models beeing constructed
         all_affected_models = get_included_models(model)
-        models_to_be_removed = filter(
+        models_to_be_removed = list(filter(
                 lambda x: hasattr(x, "_tx_reference_resolver"),
-                all_affected_models)
+                all_affected_models))
         for m in all_affected_models:
             remove_models_from_repositories(m, models_to_be_removed)
         raise e

--- a/textx/model.py
+++ b/textx/model.py
@@ -616,9 +616,8 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
         is_primitive_type = False
         try:
             model._tx_filename = file_name
-            # mark model as "model being constructed" (see "except"-block
-            # of current "try"-block):
-            model._tx_reference_resolver = None
+            # mark model as "model being constructed"
+            _start_model_construction(model)
         except AttributeError:
             # model is some primitive python type (e.g. str)
             is_primitive_type = True
@@ -719,6 +718,17 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
     return model
 
 
+def _start_model_construction(model):
+    """
+    Start model construction (internal design: use
+    the attribute _tx_reference_resolver to mark a
+    model being in construction).
+    See: _remove_all_affected_models_in_construction
+    """
+    assert not hasattr(model, "_tx_reference_resolver")
+    model._tx_reference_resolver = None
+
+
 def _remove_all_affected_models_in_construction(model):
     """
     Remove all models related to model being constructed
@@ -726,6 +736,7 @@ def _remove_all_affected_models_in_construction(model):
     This function is private to model.py, since the models
     being constructed are identified by having a reference
     resolver (this is an internal design decision of model.py).
+    See: _start_model_construction
     """
     all_affected_models = get_included_models(model)
     models_to_be_removed = list(filter(

--- a/textx/model.py
+++ b/textx/model.py
@@ -693,9 +693,7 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                 # remove all processed models from (global) repo (if present)
                 # (remove all of them, not only the model with errors,
                 # since, models with errors may be included in other models)
-                models_to_be_removed = models
-                for m in models:
-                    remove_models_from_repositories(m, models_to_be_removed)
+                remove_models_from_repositories(models, models)
                 raise e
 
         if metamodel.textx_tools_support \
@@ -742,8 +740,8 @@ def _remove_all_affected_models_in_construction(model):
     models_to_be_removed = list(filter(
         lambda x: hasattr(x, "_tx_reference_resolver"),
         all_affected_models))
-    for m in all_affected_models:
-        remove_models_from_repositories(m, models_to_be_removed)
+    remove_models_from_repositories(all_affected_models,
+                                    models_to_be_removed)
 
 
 class ReferenceResolver:

--- a/textx/model.py
+++ b/textx/model.py
@@ -716,7 +716,8 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
         # remove all models beeing constructed
         all_affected_models = get_included_models(model)
         models_to_be_removed = filter(
-                lambda x: hasattr(x, "_tx_reference_resolver"), all_affected_models)
+                lambda x: hasattr(x, "_tx_reference_resolver"),
+                all_affected_models)
         for m in all_affected_models:
             remove_models_from_repositories(m, models_to_be_removed)
         raise e

--- a/textx/model.py
+++ b/textx/model.py
@@ -668,7 +668,8 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
 
                 # final check that everything went ok
                 for m in models:
-                    assert 0 == len(get_children_of_type(Postponed.__class__, m))
+                    assert 0 == len(get_children_of_type(
+                        Postponed.__class__, m))
 
                     # We have model loaded and all link resolved
                     # So we shall do a depth-first call of object
@@ -685,7 +686,8 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                 for m in models:
                     for m2 in models:
                         if hasattr(m2._tx_metamodel, "_tx_model_repository"):
-                            m2._tx_metamodel._tx_model_repository.remove_model(m)
+                            m2._tx_metamodel.\
+                                _tx_model_repository.remove_model(m)
                         if hasattr(m2, "_tx_model_repository"):
                             m2._tx_model_repository.remove_model(m)
                 raise e
@@ -697,8 +699,8 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
             # (required for binary search)
             model._pos_crossref_list = pos_crossref_list
 
-            # Dict for storing rules where key is position of rule instance in text
-            # Sorted based on nested rules
+            # Dict for storing rules where key is position of rule instance in
+            # text. Sorted based on nested rules.
             model._pos_rule_dict = OrderedDict(sorted(pos_rule_dict.items(),
                                                       key=lambda x: x[0],
                                                       reverse=True))
@@ -707,13 +709,15 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
         # remove all models beeing constructed
         from textx.scoping import get_all_models_including_attached_models
         models = get_all_models_including_attached_models(model)
-        for m in filter(lambda x:hasattr(x,"_tx_reference_resolver"), models):
+        for m in filter(
+                lambda x: hasattr(x, "_tx_reference_resolver"), models):
             for m2 in models:
                 if hasattr(m2._tx_metamodel, "_tx_model_repository"):
                     m2._tx_metamodel._tx_model_repository.remove_model(m)
                 if hasattr(m2, "_tx_model_repository"):
                     m2._tx_model_repository.remove_model(m)
-        for m in filter(lambda x:hasattr(x,"_tx_reference_resolver"), models):
+        for m in filter(
+                lambda x: hasattr(x, "_tx_reference_resolver"), models):
             del m._tx_reference_resolver
         raise e
 

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -334,7 +334,7 @@ def is_file_included(filename, model):
 
 def remove_models_from_repositories(model, models_to_be_removed):
     """
-    Removed models from all relevant repositories (_tx_model_repository
+    Remove models from all relevant repositories (_tx_model_repository
     of models and metamodel, if applicable).
 
     Args:

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -332,21 +332,27 @@ def is_file_included(filename, model):
         return False
 
 
-def remove_models_from_repositories(model, models_to_be_removed):
+def remove_models_from_repositories(model_or_list_of_models,
+                                    models_to_be_removed):
     """
     Remove models from all relevant repositories (_tx_model_repository
-    of model and metamodel, if applicable).
+    of model_or_list_of_models and related metamodel(s), if applicable).
 
     Args:
-        model: the model from which the models_to_be_removed have to
-               be removed
+        model_or_list_of_models: the model (or a list of models) from
+               which the models_to_be_removed have to be removed.
         models_to_be_removed: models to be removed
 
     Returns:
         None
     """
-    if hasattr(model._tx_metamodel, "_tx_model_repository"):
-        model._tx_metamodel. \
-            _tx_model_repository.remove_models(models_to_be_removed)
-    if hasattr(model, "_tx_model_repository"):
-        model._tx_model_repository.remove_models(models_to_be_removed)
+    if isinstance(model_or_list_of_models, list):
+        models = model_or_list_of_models
+    else:
+        models = [model_or_list_of_models]
+    for model in models:
+        if hasattr(model._tx_metamodel, "_tx_model_repository"):
+            model._tx_metamodel. \
+                _tx_model_repository.remove_models(models_to_be_removed)
+        if hasattr(model, "_tx_model_repository"):
+            model._tx_model_repository.remove_models(models_to_be_removed)

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -331,9 +331,11 @@ def is_file_included(filename, model):
     else:
         return False
 
+
 def remove_models_from_repositories(model, models_to_be_removed):
     """
-    Removed models from all relevant repositories.
+    Removed models from all relevant repositories (_tx_model_repository
+    of models and metamodel, if applicable).
 
     Args:
         model: the model from which has to be removed

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -335,10 +335,11 @@ def is_file_included(filename, model):
 def remove_models_from_repositories(model, models_to_be_removed):
     """
     Remove models from all relevant repositories (_tx_model_repository
-    of models and metamodel, if applicable).
+    of model and metamodel, if applicable).
 
     Args:
-        model: the model from which has to be removed
+        model: the model from which the models_to_be_removed have to
+               be removed
         models_to_be_removed: models to be removed
 
     Returns:

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -332,24 +332,21 @@ def is_file_included(filename, model):
         return False
 
 
-def remove_models_from_repositories(model_or_list_of_models,
+def remove_models_from_repositories(models,
                                     models_to_be_removed):
     """
     Remove models from all relevant repositories (_tx_model_repository
-    of model_or_list_of_models and related metamodel(s), if applicable).
+    of models and related metamodel(s), if applicable).
 
     Args:
-        model_or_list_of_models: the model (or a list of models) from
+        models: the list of models from
                which the models_to_be_removed have to be removed.
         models_to_be_removed: models to be removed
 
     Returns:
         None
     """
-    if isinstance(model_or_list_of_models, list):
-        models = model_or_list_of_models
-    else:
-        models = [model_or_list_of_models]
+    assert isinstance(models, list)
     for model in models:
         if hasattr(model._tx_metamodel, "_tx_model_repository"):
             model._tx_metamodel. \

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -95,6 +95,10 @@ class GlobalModelRepository(object):
         self.all_models.remove_model(model)
         self.local_models.remove_model(model)
 
+    def remove_models(self, models):
+        for m in models:
+            self.remove_model(m)
+
     def load_models_using_filepattern(
             self, filename_pattern, model, glob_args, is_main_model=False,
             encoding='utf-8', add_to_local_models=True):
@@ -326,3 +330,20 @@ def is_file_included(filename, model):
         return all_entries.has_model(filename)
     else:
         return False
+
+def remove_models_from_repositories(model, models_to_be_removed):
+    """
+    Removed models from all relevant repositories.
+
+    Args:
+        model: the model from which has to be removed
+        models_to_be_removed: models to be removed
+
+    Returns:
+        None
+    """
+    if hasattr(model._tx_metamodel, "_tx_model_repository"):
+        model._tx_metamodel. \
+            _tx_model_repository.remove_models(models_to_be_removed)
+    if hasattr(model, "_tx_model_repository"):
+        model._tx_model_repository.remove_models(models_to_be_removed)

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -52,7 +52,7 @@ class ModelRepository(object):
             if m == model:
                 filename = f
         if filename:
-            print("*** delete {}".format(filename))
+            # print("*** delete {}".format(filename))
             del self.filename_to_model[filename]
 
 

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -52,7 +52,7 @@ class ModelRepository(object):
             if m == model:
                 filename = f
         if filename:
-            # print("*** delete {}".format(filename))
+            print("*** delete {}".format(filename))
             del self.filename_to_model[filename]
 
 

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -306,7 +306,7 @@ class ImportURI(scoping.ModelLoader):
             add_to_local_models = True
             if self.importURI_to_scope_name is not None:
                 obj.name = self.importURI_to_scope_name(obj)
-                print("setting name to {}".format(obj.name))
+                # print("setting name to {}".format(obj.name))
             if hasattr(obj, "name"):
                 if obj.name is not None and obj.name != "":
                     add_to_local_models = not self.importAs

--- a/textx/scoping/tools.py
+++ b/textx/scoping/tools.py
@@ -239,7 +239,7 @@ def get_unique_named_object_in_all_models(root, name):
 
     a = []
     for m in src:
-        print("analyzing {}".format(m._tx_filename))
+        # print("analyzing {}".format(m._tx_filename))
         a = a + get_children(
             lambda x: hasattr(x, 'name') and x.name == name, m)
 


### PR DESCRIPTION
 * Problem was, that **with a global repository in the metamodel**, that **models with errors were cached** and reused (w/o beeing checked). Related docs: http://textx.github.io/textX/stable/scoping/#note-on-uniqueness-of-model-elements-global-repository
 * Solution: **delete all models touched while loading a model, when an error occurs** in object processors (in all repositories). - - > **strong exception safety guarantee**. 
 * _Alternative (not implemented)_: re-check cached models (Problem: what happens if the object processor modifies the model? Not good running object processors twice)
 * Minor: added (commented) printfs and commented some old printfs found in the codebase.

Rebased version - follow-up PR (see #198)

@igordejanovic to easily review the changes, enable "Hide whitespace changes" in your diff-viewer (e.g. github browser window). There is mainly one change (at two locations) in model.py to handle exceptions.

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated
- [x] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [x] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`).


[commit messages]: https://chris.beams.io/posts/git-commit/