### PR TITLE
issue 206: regex/whitespace issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ please take a look at related PRs and issues and see if the change affects you.
 
   - Changed the parser rule for regex matches. Spaces are not stripped any more form 
     the beginning and the end of the regexp-pattern. This could be possible
-    **BIC** for some special cases. Here, it is handled as bug [#208].
+    **BIC** for some special cases [#208].
   - Changed function name `textx.scoping.get_all_models_including_attached_models`
     to `textx.scoping.get_included_models` (marked old function
     as deprecated) ([#197]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Changed
 
+  - Changed the parser rule for regex matches. Spaces are not stripped any more form 
+    the beginning and the end of the regexp-pattern. This could be possible
+    **BIC** for some special cases. Here, it is handled as bug [#208].
   - Changed function name `textx.scoping.get_all_models_including_attached_models`
     to `textx.scoping.get_included_models` (marked old function
     as deprecated) ([#197]).
@@ -409,6 +412,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#208]: https://github.com/textX/textX/pull/208
 [#200]: https://github.com/textX/textX/issues/200
 [#197]: https://github.com/textX/textX/issues/197
 [#188]: https://github.com/textX/textX/issues/188

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,15 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Changed
 
-  - Changed the parser rule for regex matches. Spaces are not stripped any more form 
-    the beginning and the end of the regexp-pattern. This could be possible
+  - Changed the parser rule for regex matches. Spaces are not stripped any more
+    from the beginning and the end of the regexp-pattern. This could be possible
     **BIC** for some special cases [#208].
   - Changed function name `textx.scoping.get_all_models_including_attached_models`
     to `textx.scoping.get_included_models` (marked old function
     as deprecated) ([#197]).
   - Delete all models touched while loading a model, when an error occurs 
     while loading in all repositories (strong exception safety guarantee) ([#200]).
+
 
 ## [v2.0.1] (released: 2019-05-20)
 

--- a/tests/functional/regressions/test_issue206_regex.py
+++ b/tests/functional/regressions/test_issue206_regex.py
@@ -1,0 +1,20 @@
+from __future__ import unicode_literals
+from textx.metamodel import metamodel_from_str
+
+
+def xtest_issue206_regex_reference1():
+    mm = metamodel_from_str('''
+        Word: ('bar' /[ ]*/)*;
+    ''', skipws=False, debug=False)
+
+    m = mm.model_from_str('''bar bar''', debug=False)
+    assert m is not None
+
+
+def test_issue206_regex():
+    mm = metamodel_from_str('''
+        Word: ('bar' / */)*;
+    ''', skipws=False, debug=False)
+
+    m = mm.model_from_str('''bar bar''', debug=False)
+    assert m is not None

--- a/tests/functional/test_textx_language.py
+++ b/tests/functional/test_textx_language.py
@@ -820,11 +820,11 @@ def test_empty_strmatch():
 def test_empty_regexmatch():
     """
     Test emtpy regex match.
-    Note, there must be at least one space between slashes or else it will be
-    parsed as line comment.
+    Note, there must be some regex-code between slashes or else it will be
+    parsed as line comment, e.g. "()".
     """
     grammar = """
-    Rule: first=/ / 'a';
+    Rule: first=/()/ 'a';
     """
     mm = metamodel_from_str(grammar)
     model = mm.model_from_str('a')

--- a/tests/functional/test_textx_language.py
+++ b/tests/functional/test_textx_language.py
@@ -819,7 +819,7 @@ def test_empty_strmatch():
 
 def test_empty_regexmatch():
     """
-    Test emtpy regex match.
+    Test empty regex match.
     Note, there must be some regex-code between slashes or else it will be
     parsed as line comment, e.g. "()".
     """
@@ -829,6 +829,12 @@ def test_empty_regexmatch():
     mm = metamodel_from_str(grammar)
     model = mm.model_from_str('a')
     assert model
+
+    grammar = """
+    Rule: first=// 'a';
+    """
+    with pytest.raises(TextXSyntaxError):
+        metamodel_from_str(grammar)
 
 
 def test_default_attribute_values():

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -845,10 +845,7 @@ class TextXVisitor(PTNodeVisitor):
         return StrMatch(to_match, ignore_case=self.metamodel.ignore_case)
 
     def visit_re_match(self, node, children):
-        try:
-            to_match = node.extra_info.group(1)
-        except IndexError:
-            to_match = ''
+        to_match = node.extra_info.group(1)
         # print("**** visit_re_match, to_match == '{}'".format(to_match))
         regex = RegExMatch(to_match,
                            ignore_case=self.metamodel.ignore_case)

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -72,7 +72,7 @@ def obj_ref_rule():         return ident
 def class_name():           return qualified_ident
 
 def str_match():            return string_value
-def re_match():             return "/", _(r"((\\/)|[^/])*"), "/"
+def re_match():             return _(r"/((?:(?:\\/)|[^/])*)/")
 def ident():                return _(r'\w+')
 def qualified_ident():      return _(r'\w+(\.\w+)?')
 def integer():              return _(r'[-+]?[0-9]+')
@@ -846,9 +846,10 @@ class TextXVisitor(PTNodeVisitor):
 
     def visit_re_match(self, node, children):
         try:
-            to_match = children[0]
+            to_match = node.extra_info.group(1)
         except IndexError:
             to_match = ''
+        # print("**** visit_re_match, to_match == '{}'".format(to_match))
         regex = RegExMatch(to_match,
                            ignore_case=self.metamodel.ignore_case)
         try:


### PR DESCRIPTION
Changed the parser rule for regex matches. Spaces are not stripped any more form the beginning and the end of the regexp-pattern. This could be possible **BIC** for some special cases. Here, it is handled as bug and the PR thus proposed to be included in the current master (to be discussed!).

See issue #206 

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Commit messages are meaningful (see [this][commit messages] for details) - squash
- [x] Tests have been included and/or updated
- [n/a] Docstrings have been included and/or updated, as appropriate
- [n/a] Standalone docs have been updated accordingly
- [x] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`).


[commit messages]: https://chris.beams.io/posts/git-commit/
