### PR TITLE
issue205 skipws propagation (regression tests)

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -824,6 +824,10 @@ specified in brackets (`[ ]`) at the beginning of the rule's definition after
 the rule's name. Currently, they are used to alter parser configuration for
 whitespace handling on the rule level.
 
+Rule modifiers act on the current rule and all rules referenced inside the rule 
+(recursively): unless a refrenced rule has an explicit rule modifier, the currently
+active modifier state is propagated to referenced rules.
+
 There are two rule modifiers at the moment:
 
 * **skipws, noskipws** - are used to enable/disable whitespace skipping during

--- a/tests/functional/regressions/test_issue205_skipws_propagation.py
+++ b/tests/functional/regressions/test_issue205_skipws_propagation.py
@@ -1,0 +1,41 @@
+from __future__ import unicode_literals
+
+import pytest
+from textx import metamodel_from_str, TextXSyntaxError
+
+
+def test_issue205_skipws_propagation():
+    """
+    Test a problem found in Arpeggio not maintaining `skipws/noskipws` applied
+    to ordered choice root rule.
+    Reported at SO: https://stackoverflow.com/questions/57944531/how-do-you-correctly-mix-textx-skipws-non-skipws  # noqa
+    """
+
+    mm = metamodel_from_str(r'''
+            Sentence[skipws]: words*=Word;
+            Word[noskipws]: ID '.' | ID | '.';
+        ''')
+
+    # If ```noskipws``` from the ```Word``` rule is obeyed then this won't
+    # parse as there is no rule to consume spaces in between the words. In the
+    # unfixed Arpeggio version ```skipws``` from ```Sentence``` would nullify
+    # ```noskipws``` from Word so the parse will not fail but it would not be
+    # what should be expected.
+    with pytest.raises(TextXSyntaxError):
+        mm.model_from_str('''foo bar .''')
+
+    # We should consume spaces explicitly. Here, we show that a rule with the
+    # ```noskipws``` rule modifier is able to consume spaces explicitly. Match
+    # suppression (-) is employed to exclude these spaces from the target value
+    # (this means the ```Word``` does not include the spaces in its value).
+    # Note: ```skipws``` of Sentence does not consume the spaces between the
+    # words, because the rule modifiers
+    # (http://textx.github.io/textX/stable/grammar/#rule-modifiers) apply
+    # immediately. Thus, we need to consume the extra spaces before a word.
+    mm = metamodel_from_str(r'''
+            Sentence[skipws]: words*=Word;
+            Word[noskipws]: /\s*/- (ID '.' | ID | '.');
+        ''')
+
+    m = mm.model_from_str('''foo bar .''')
+    assert len(m.words) == 3


### PR DESCRIPTION
Here, we add some tests to check and demonstrate the propagation of skipws/noswkips across rules.

We should consider to add this tests, once the Arpeggio fix for the Arpeggio issue 61 is done.

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Commit messages are meaningful (see [this][commit messages] for details) - squash
- [x] Tests have been included and/or updated
- [n/a] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [n/a] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`).


[commit messages]: https://chris.beams.io/posts/git-commit/
