### PR TITLE
textX-LS integration (v0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Changed
 
+  - Allow passing kwargs (specially - file_name) argument when loading metamodel
+    from string (needed for `textX-LS v0.1.0`) ([#211]).
   - Changed the parser rule for regex matches. Spaces are not stripped any more
     from the beginning and the end of the regexp-pattern. This could be possible
     **BIC** for some special cases [#208].
@@ -413,6 +415,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#211]: https://github.com/textX/textX/pull/211
 [#208]: https://github.com/textX/textX/pull/208
 [#200]: https://github.com/textX/textX/issues/200
 [#197]: https://github.com/textX/textX/issues/197


### PR DESCRIPTION
<!-- Please don't remove/change code review checklist -->

Changes needed for integration with language server:

- allow passing _kwargs_ (specially - _file_name_) argument when loading metamodel from string 

Note that I have merged changes from branch `analysis/issue193_rebase` because I needed those fixes. I think this PR depends on https://github.com/textX/textX/pull/194 (I haven't compared `analysis/issue193_rebase` and `analysis/issue193` branches, so I am not sure).

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`).


[commit messages]: https://chris.beams.io/posts/git-commit/
