### PR TITLE
fixed todo and adapted test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Changed
 
+  - Fixed type checking for references to builtin elements ([#218])
   - Allow passing kwargs (specially - file_name) argument when loading metamodel
     from string (needed for `textX-LS v0.1.0`) ([#211]).
   - Changed the parser rule for regex matches. Spaces are not stripped any more
@@ -418,6 +419,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#218]: https://github.com/textX/textX/pull/218
 [#211]: https://github.com/textX/textX/pull/211
 [#208]: https://github.com/textX/textX/pull/208
 [#200]: https://github.com/textX/textX/issues/200

--- a/tests/functional/test_scoping/test_buildins.py
+++ b/tests/functional/test_scoping/test_buildins.py
@@ -7,14 +7,18 @@ from textx import metamodel_from_str
 
 metamodel_str = '''
 Model:
+    persons*=Person
     things+=Thing
+    refs*=PersonRef
 ;
-
+Person: 'person' name=ID;
+PersonRef: 'ref' ref=[Person];
 Thing:
     'thing' name=ID '{'
     inner*=[Thing]
     '}'
 ;
+
 '''
 
 
@@ -33,6 +37,7 @@ def test_buildins():
     - one model w/o buildins
     - one model with buildins
     - one model with unknown references (errors)
+    - one model with references to builtins of wrong type
     """
     #################################
     # META MODEL DEF
@@ -50,15 +55,23 @@ def test_buildins():
     #################################
 
     my_metamodel.model_from_str('''
+    person P
+    person I
     thing A {}
     thing B {}
     thing C {A B}
+    ref P
+    ref I
     ''')
 
     my_metamodel.model_from_str('''
+    person P
+    person I
     thing A {}
     thing B {}
     thing C {A B OneThing OtherThing}
+    ref P
+    ref I
     ''')
 
     with raises(textx.exceptions.TextXSemanticError,
@@ -67,6 +80,18 @@ def test_buildins():
         thing A {}
         thing B {}
         thing C {A B OneThing OtherThing UnknownPart}
+        ''')
+
+    with raises(textx.exceptions.TextXSemanticError,
+                match=r'.*Unknown object "OneThing" of class "Person".*'):
+        my_metamodel.model_from_str('''
+            person P
+            person I
+            thing A {}
+            thing B {}
+            thing C {A B OneThing OtherThing}
+            ref OneThing
+            ref OtherThing
         ''')
 
     #################################
@@ -84,6 +109,7 @@ def test_buildins_fully_qualified_name():
     - one model w/o buildins
     - one model with buildins
     - one model with unknown references (errors)
+    - one model with references to builtins of wrong type
     """
     #################################
     # META MODEL DEF
@@ -102,15 +128,23 @@ def test_buildins_fully_qualified_name():
     #################################
 
     my_metamodel.model_from_str('''
+    person P
+    person I
     thing A {}
     thing B {}
     thing C {A B}
+    ref P
+    ref I
     ''')
 
     my_metamodel.model_from_str('''
+    person P
+    person I
     thing A {}
     thing B {}
     thing C {A B OneThing OtherThing}
+    ref P
+    ref I
     ''')
 
     with raises(textx.exceptions.TextXSemanticError,
@@ -119,6 +153,18 @@ def test_buildins_fully_qualified_name():
         thing A {}
         thing B {}
         thing C {A B OneThing OtherThing UnknownPart}
+        ''')
+
+    with raises(textx.exceptions.TextXSemanticError,
+                match=r'.*Unknown object "OneThing" of class "Person".*'):
+        my_metamodel.model_from_str('''
+            person P
+            person I
+            thing A {}
+            thing B {}
+            thing C {A B OneThing OtherThing}
+            ref OneThing
+            ref OtherThing
         ''')
 
     #################################

--- a/textx/model.py
+++ b/textx/model.py
@@ -831,8 +831,13 @@ class ReferenceResolver:
                     # As a fall-back search builtins if given
                     if metamodel.builtins:
                         if crossref.obj_name in metamodel.builtins:
-                            # TODO: Classes must match
-                            resolved = metamodel.builtins[crossref.obj_name]
+                            from textx import textx_isinstance
+                            if textx_isinstance(
+                                    metamodel.builtins[crossref.obj_name],
+                                    crossref.cls
+                            ):
+                                resolved = metamodel.builtins[
+                                    crossref.obj_name]
 
                 if not resolved:
                     line, col = self.parser.pos_to_linecol(crossref.position)

--- a/textx/scoping/tools.py
+++ b/textx/scoping/tools.py
@@ -43,6 +43,8 @@ def textx_isinstance(obj, obj_cls):
     Returns:
         True if obj is an instance of obj_cls.
     """
+    if obj_cls.__name__ == "OBJECT":
+        return True
     if isinstance(obj, obj_cls):
         return True
     if hasattr(obj_cls, "_tx_fqn") and hasattr(obj, "_tx_fqn"):


### PR DESCRIPTION
See #217: Fixed type checking for references to builtin elements

The effect (w/o this PR) is, that you can use a built-in object for any reference (independent of its type). Compare the adapted unit tests. 

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [n/a] Commit messages are meaningful (see [this][commit messages] for details) -squash
- [X] Tests have been included and/or updated
- [no] Docstrings have been included and/or updated, as appropriate
- [no] Standalone docs have been updated accordingly
- [x] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
