### PR TITLE
fixed error code handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Changed
 
+  - Fixed return value of textx generate and check commands: we return a failure on error now ([#222])
   - Fixed type checking for references to builtin elements ([#218])
   - Allow passing kwargs (specially - file_name) argument when loading metamodel
     from string (needed for `textX-LS v0.1.0`) ([#211]).
@@ -423,6 +424,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#222]: https://github.com/textX/textX/pull/222
 [#219]: https://github.com/textX/textX/pull/219
 [#218]: https://github.com/textX/textX/pull/218
 [#211]: https://github.com/textX/textX/pull/211

--- a/tests/functional/registration/test_check.py
+++ b/tests/functional/registration/test_check.py
@@ -71,7 +71,7 @@ def test_check_invalid_model():
                               'models', 'data_flow_including_error.eflow')
     runner = CliRunner()
     result = runner.invoke(textx, ['check', model_file])
-    assert result.exit_code == 0
+    assert result.exit_code != 0
     assert 'error: types must be lowercase' in result.output
 
 

--- a/textx/cli/check.py
+++ b/textx/cli/check.py
@@ -70,7 +70,10 @@ def check(textx):
                 click.echo("{}: OK.".format(os.path.abspath(model_file)))
 
         except TextXRegistrationError as e:
-            click.echo(e.message)
+            raise click.ClickException(e.message)
 
         except TextXError as e:
-            click.echo(e)
+            raise click.ClickException(str(e))
+
+        except Exception as e:
+            raise click.ClickException(str(e))

--- a/textx/cli/generate.py
+++ b/textx/cli/generate.py
@@ -104,7 +104,10 @@ def generate(textx):
                           **custom_args)
 
         except TextXRegistrationError as e:
-            click.echo(e.message)
+            raise click.ClickException(e.message)
 
         except TextXError as e:
-            click.echo(e)
+            raise click.ClickException(str(e))
+
+        except Exception as e:
+            raise click.ClickException(str(e))


### PR DESCRIPTION
According to http://click.palletsprojects.com/en/5.x/exceptions/ click handle return values in a special way, if exceptions are thrown. In our case, textx was not returning an error code, if a model error occurs. This PR is a quickfix...

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [X] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated
- [no] Docstrings have been included and/or updated, as appropriate
- [no] Standalone docs have been updated accordingly
- [x] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
