### PR TITLE
Enable passing of metamodel params in mm registration API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ please take a look at related PRs and issues and see if the change affects you.
   - Fixed return value of textx generate and check commands: we return a failure
     on error now ([#222])
   - Fixed type checking for references to builtin elements ([#218])
+  
+### Changed
+
+  - Allow passing kwargs in `metamodel_for_file/language` registration API
+    calls. ([#224])
 
 
 ## [v2.1.0] (released: 2019-10-12)
@@ -428,6 +433,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#224]: https://github.com/textX/textX/pull/224
 [#222]: https://github.com/textX/textX/pull/222
 [#219]: https://github.com/textX/textX/pull/219
 [#218]: https://github.com/textX/textX/pull/218

--- a/docs/registration.md
+++ b/docs/registration.md
@@ -383,20 +383,31 @@ All classes and functions documented here are directly importable from `textx` m
   parameters
 - `clear_language_registrations()` - deletes all languages registered
   programmatically. Note: languages registered through `setup.py` won't be removed
-- `metamodel_for_language(language_name)` - returns a meta-model for the given language name
+- `metamodel_for_language(language_name, **kwargs)` - returns a meta-model for
+  the given language name. `kwargs` are additional keyword arguments passed to
+  meta-model factory callable, similarly to `metamodel_from_str/file`.
 - `language_for_file(file_name_or_pattern)` - returns an instance of `LanguageDesc`
   for the given file name or file name pattern. Raises `TextXRegistrationError`
   if no language or multiple languages can parse the given file
 - `languages_for_file(file_name_or_pattern)` - returns a list of `LanguageDesc`
   for the given file name or file name pattern
-- `metamodel_for_file(file_name_or_pattern)` - returns a language meta-model for
-  a language that can parse the given file name or file name pattern. Raises
+- `metamodel_for_file(file_name_or_pattern, **kwargs)` - returns a language
+  meta-model for a language that can parse the given file name or file name
+  pattern. `kwargs` are additional keyword arguments passed to meta-model
+  factory callable, similarly to `metamodel_from_str/file`. Raises
   `TextXRegistrationError` if no language or multiple languages can parse the
   given file
 - `metamodels_for_file(file_name_or_pattern)` - returns a list of meta-models
   for languages that can parse the given file name or file pattern
 - `language` - a decorator used for [language registration](#registering-a-new-language)
 
+
+!!! warning
+
+    meta-model instances are cached with a given `kwargs` so the same instance
+    can be retrieved in further calls without giving `kwargs`. Whenever `kwargs`
+    is given in `metamodel_for_file/language` call, a brand new meta-model will 
+    be created and cached for further use.
 
 
 ### Generator registration API

--- a/tests/functional/registration/test_registration.py
+++ b/tests/functional/registration/test_registration.py
@@ -10,8 +10,8 @@ from textx import (metamodel_from_str,
 from textx.metamodel import TextXMetaModel
 
 
-def mymetamodel_callable():
-    return metamodel_from_str('MyModel: INT;')
+def mymetamodel_callable(**kwargs):
+    return metamodel_from_str('MyModel: INT;', **kwargs)
 
 
 def generator_callable():
@@ -140,6 +140,31 @@ def test_metamodel_for_language(language_registered):
     assert isinstance(mm, TextXMetaModel)
 
 
+def test_metamodel_for_language_with_params(language_registered):
+    """
+    Test that passing in kwargs to `metamodel_for_language` call will create a
+    brand new meta-model while the old instance will be returned if no `kwargs`
+    are given.
+    """
+    class MyModel:
+        pass
+
+    mm = metamodel_for_language('test-lang', ignore_case=True,
+                                classes=[MyModel])
+    assert mm.ignore_case
+    assert 'MyModel' in mm.user_classes
+
+    # Now we can call without kwargs and we still get the same instance
+    mm2 = metamodel_for_language('test-lang')
+    assert mm is mm2
+
+    # But, passing kwargs again creates a new meta-model
+    mm3 = metamodel_for_language('test-lang', ignore_case=False,
+                                 classes=[MyModel])
+    assert not mm3.ignore_case
+    assert 'MyModel' in mm.user_classes
+
+
 def test_metamodel_for_file(language_registered):
     """
     Test finding a meta-model for the given file or file pattern.
@@ -152,6 +177,29 @@ def test_metamodel_for_file(language_registered):
 
     mm = metamodel_for_file('somefile*.test')
     assert isinstance(mm, TextXMetaModel)
+
+
+def test_metamodel_for_file_with_params(language_registered):
+    """
+    Test that passing in kwargs to `metamodel_for_file` call will create a
+    brand new meta-model while the old instance will be returned if no `kwargs`
+    are given.
+    """
+    class MyModel:
+        pass
+
+    mm = metamodel_for_file('*.test', ignore_case=True, classes=[MyModel])
+    assert mm.ignore_case
+    assert 'MyModel' in mm.user_classes
+
+    # Now we can call without kwargs and we still get the same instance
+    mm2 = metamodel_for_file('*.test')
+    assert mm is mm2
+
+    # But, passing kwargs again creates a new meta-model
+    mm3 = metamodel_for_file('*.test', ignore_case=False, classes=[MyModel])
+    assert not mm3.ignore_case
+    assert 'MyModel' in mm.user_classes
 
 
 def test_multiple_languages_for_the_same_pattern():

--- a/textx/registration.py
+++ b/textx/registration.py
@@ -236,20 +236,20 @@ def clear_generator_registrations():
     generators = None
 
 
-def metamodel_for_language(language_name):
+def metamodel_for_language(language_name, **kwargs):
     """
     Load and return the meta-model for the given language.
     Cache it for further use.
     """
     language_name = language_name.lower()
-    if language_name not in metamodels:
+    if language_name not in metamodels or kwargs:
         from textx.metamodel import TextXMetaModel, TextXMetaMetaModel
         language = language_description(language_name)
         if (isinstance(language.metamodel, TextXMetaModel)
                 or isinstance(language.metamodel, TextXMetaMetaModel)):
             metamodels[language_name] = language.metamodel
         else:
-            metamodel = language.metamodel()
+            metamodel = language.metamodel(**kwargs)
             if not (isinstance(metamodel, TextXMetaModel) or
                     isinstance(metamodel, TextXMetaMetaModel)):
                 raise TextXRegistrationError(
@@ -295,12 +295,13 @@ def metamodels_for_file(file_name_or_pattern):
             for language in languages_for_file(file_name_or_pattern)]
 
 
-def metamodel_for_file(file_name_or_pattern):
+def metamodel_for_file(file_name_or_pattern, **kwargs):
     """
     Return a meta-model that can parse the given file or raise
     `TextXRegistrationError` if more than one is registered.
     """
-    return metamodel_for_language(language_for_file(file_name_or_pattern).name)
+    return metamodel_for_language(language_for_file(file_name_or_pattern).name,
+                                  **kwargs)
 
 
 def generator(language, target):


### PR DESCRIPTION
In order to make calls `metamodel_for_file/language` symmetric to `metamodel_from_str/file` this adds keywords params to registration API calls that are used to configure the meta-models.


## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
