### PR TITLE
Better dot visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ please take a look at related PRs and issues and see if the change affects you.
   - Fixed return value of textx generate and check commands: we return a failure
     on error now ([#222])
   - Fixed type checking for references to builtin elements ([#218])
+  
+### Changed
+
+  - Dot rendering of meta-model: remove rendering of base types, improve
+    rendering of required/optional, render match rules as a single table.
+    ([#225])
 
 
 ## [v2.1.0] (released: 2019-10-12)
@@ -428,6 +434,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#225]: https://github.com/textX/textX/pull/225
 [#222]: https://github.com/textX/textX/pull/222
 [#219]: https://github.com/textX/textX/pull/219
 [#218]: https://github.com/textX/textX/pull/218

--- a/examples/render_all_grammars/render_all_grammars.py
+++ b/examples/render_all_grammars/render_all_grammars.py
@@ -3,6 +3,7 @@ from textx import metamodel_from_file
 from textx.export import metamodel_export, PlantUmlRenderer
 import fnmatch
 import os
+import sys
 from os.path import sep, join, dirname, exists
 
 
@@ -67,4 +68,7 @@ def main(path=None, debug=False, reportfilename=None):
 
 
 if __name__ == "__main__":
-    main()
+    if len(sys.argv) == 2:
+        main(sys.argv[1])
+    else:
+        main()

--- a/textx/export.py
+++ b/textx/export.py
@@ -116,8 +116,7 @@ class DotRenderer(object):
             attrs = match_abstract_str(cls)
         else:
             for attr in cls._tx_attrs.values():
-                required = "+" if attr.mult in \
-                    [MULT_ONE, MULT_ONEORMORE] else ""
+                required = attr.mult in [MULT_ONE, MULT_ONEORMORE]
                 mult_list = attr.mult in [MULT_ZEROORMORE, MULT_ONEORMORE]
                 attr_type = "list[{}]".format(attr.cls.__name__) \
                     if mult_list else attr.cls.__name__
@@ -125,8 +124,8 @@ class DotRenderer(object):
                     pass
                 else:
                     # If it is plain type
-                    attrs += "{}{}:{}\\l".format(required,
-                                                 attr.name, attr_type)
+                    attrs += "{}: {}\\l".format(
+                        attr.name, attr_type if required else "optional\<{}\>".format(attr_type))
         return '{}[ label="{{{}|{}}}"]\n\n'.format(
                 id(cls), "*{}".format(name)
                 if cls._tx_type is RULE_ABSTRACT else name, attrs)

--- a/textx/export.py
+++ b/textx/export.py
@@ -113,7 +113,7 @@ def dot_repr(o):
 class DotRenderer(object):
 
     def __init__(self):
-        self.match_rules = []
+        self.match_rules = set()
 
     def get_header(self):
         return HEADER
@@ -136,7 +136,8 @@ class DotRenderer(object):
         name = cls.__name__
         attrs = ""
         if cls._tx_type is RULE_MATCH:
-            self.match_rules.append(cls)
+            if cls.__name__ not in BASE_TYPE_NAMES:
+                self.match_rules.add(cls)
             return ''
         elif cls._tx_type is not RULE_ABSTRACT:
             for attr in cls._tx_attrs.values():
@@ -173,7 +174,7 @@ class DotRenderer(object):
 class PlantUmlRenderer(object):
 
     def __init__(self):
-        self.match_rules = []
+        self.match_rules = set()
 
     def get_header(self):
         return '''@startuml
@@ -200,7 +201,8 @@ set namespaceSeparator .
         attrs = ""
         stereotype = ""
         if cls._tx_type is RULE_MATCH:
-            self.match_rules.append(cls)
+            if cls.__name__ not in BASE_TYPE_NAMES:
+                self.match_rules.add(cls)
             return ''
         elif cls._tx_type is not RULE_COMMON:
             stereotype += cls._tx_type

--- a/textx/export.py
+++ b/textx/export.py
@@ -263,6 +263,8 @@ def metamodel_export_tofile(metamodel, f, renderer=None):
             for attr in cls._tx_attrs.values():
                 if attr.ref and attr.cls.__name__ != 'OBJECT':
                     f.write(renderer.render_attr_link(cls, attr))
+                if attr.cls not in classes:
+                    f.write(renderer.render_class(attr.cls))
         for inherited_by in cls._tx_inh_by:
             f.write(renderer.render_inherited_by(cls, inherited_by))
     f.write("{}".format(renderer.get_trailer()))


### PR DESCRIPTION
Improved dot visualization of meta-models:

- rendering of base-types removed
- optional/required attrs rendering changed
- all match rules are rendered as a single table

If this looks better I'll update images in the docs.

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
