### PR TITLE
Split CLI/dev tools to a separate project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
     - cd ../textX
 
 install:
-    - ./install-all-dev.sh
+    - ./install-test.sh
 
 script:
     - ./runtests.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ please take a look at related PRs and issues and see if the change affects you.
   
 ### Changed
 
+  - Cleanup of setup configuration and install scripts [#231]
   - Dot/PlantUML rendering of meta-models: remove rendering of base types,
     improve rendering of required/optional, render match rules as a single
     table. ([#225])
@@ -438,6 +439,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#231]: https://github.com/textX/textX/pull/231
 [#228]: https://github.com/textX/textX/pull/228
 [#225]: https://github.com/textX/textX/pull/225
 [#224]: https://github.com/textX/textX/pull/224

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,15 +82,13 @@ Ready to contribute? Here's how to set up `textX` for local development.
 
         $ git clone git@github.com:your_name_here/textX.git
 
-3. Install your local copy into a virtualenv. Assuming you have
-   [virtualenv](https://virtualenv.pypa.io/en/latest) installed, this is how you
-   set up your fork for local development:
+3. Install your local copy into a virtualenv. This is how you set up your fork
+   for local development:
 
         $ cd textX/
-        $ virtualenv venv
+        $ python -m venv venv
         $ source venv/bin/activate
-        $ pip install -r requirements_dev.txt
-        $ pip install -e .
+        $ ./install-dev.sh 
         
     Previous stuff is needed only the first time. To continue working on textX
     later you just do:
@@ -123,6 +121,10 @@ Ready to contribute? Here's how to set up `textX` for local development.
         $ py.test tests/functional/
         $ coverage run --source textx -m py.test tests/functional
         $ coverage report
+        
+   You can run all this at once with provided script `runtests.sh`
+   
+        $ ./runtests.sh
 
    In case you have doubts, have also a look at the html rendered version of
    the coverage results:

--- a/docs/textx_command.md
+++ b/docs/textx_command.md
@@ -29,7 +29,12 @@ textX registers several sub-commands:
 
     Please, see [Extending textx command](#extending-textx-command) section
     bellow on how to define your own sub-commands investigate `setup.py` of textX project. 
-
+    
+    Some of development commands/tools are registered by
+    [textX-dev](https://github.com/textX/textX-dev) project which is an optional dev
+    dependency of textX. In order to have all these commands available you can
+    either install `textX-dev` project or install textX dev dependencies with `pip
+    install textX[dev]`.
 
 
 ## Using the tool
@@ -50,8 +55,6 @@ Commands:
   generate         Run code generator on a provided model(s).
   list-generators  List all registered generators
   list-languages   List all registered languages
-  testcommand      This command will be found as a sub-command of `textx`...
-  testgroup        Here we write group explanation.
 ```
       
 
@@ -138,6 +141,13 @@ setup(
     }
 )
 ```
+
+!!! tip
+
+    If you prefer a more declarative approach you can use `setup.cfg` instead of
+    `setup.py` to configure your project and register textx commands. For an
+    idea see how [textX project registers its commands](https://github.com/textX/textX/blob/master/setup.cfg).
+
 
 If you install now your project in the same Python environment where `textX` is
 installed you will see that `textx` command now has your command registered.

--- a/install-all-dev.sh
+++ b/install-all-dev.sh
@@ -1,11 +1,7 @@
 #!/bin/sh
 
 pip install --upgrade pip || exit 1
-pip install python-coveralls
-pip install Jinja2
-pip install coverage
-pip install flake8
-pip install -e . || exit 1
+pip install -e .[dev,test] || exit 1
 pip install -e tests/functional/subcommands/example_project || exit 1
 pip install -e tests/functional/registration/projects/types_dsl || exit 1
 pip install -e tests/functional/registration/projects/data_dsl || exit 1

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+pip install --upgrade pip || exit 1
+pip install -e .[dev] || exit 1
+./install-test.sh

--- a/install-test.sh
+++ b/install-test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 pip install --upgrade pip || exit 1
-pip install -e .[dev,test] || exit 1
+pip install -e .[test] || exit 1
 pip install -e tests/functional/subcommands/example_project || exit 1
 pip install -e tests/functional/registration/projects/types_dsl || exit 1
 pip install -e tests/functional/registration/projects/data_dsl || exit 1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,0 @@
-pytest
-flake8
-coverage
-jinja2
-mkdocs
-mike

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ license = MIT
 description = Meta-language for DSL implementation inspired by Xtext
 keywords = parser, meta-language, meta-model, language, DSL
 url = https://github.com/textX/textX
-long_description = file: README
+long_description = file: README.md
 long_description_content_type = text/markdown
 classifiers =
     Development Status :: 5 - Production/Stable

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,61 @@
 [metadata]
+name = textX
+author = Igor R. Dejanovic
+author_email = igor.dejanovic@gmail.com
+license = MIT
+description = Meta-language for DSL implementation inspired by Xtext
+keywords = parser, meta-language, meta-model, language, DSL
+url = https://github.com/textX/textX
+long_description = file: README
+long_description_content_type = text/markdown
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    Intended Audience :: Information Technology
+    Intended Audience :: Science/Research
+    Topic :: Software Development :: Interpreters
+    Topic :: Software Development :: Compilers
+    Topic :: Software Development :: Libraries :: Python Modules
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 description-file = README.md
+
+[options]
+packages = textx, textx.scoping
+zip_safe = False
+install_requires = Arpeggio>=1.9.0
+include_package_data = True
+package_dir =
+    textx = textx
+setup_requires =
+    setuptools_scm
+    wheel
+
+[options.extras_require]
+dev =
+    textx-dev
+    mkdocs
+    mike
+test =
+     textx-dev
+     flake8
+     tox
+     jinja2
+     coverage
+     coveralls
+     pytest
+
+[options.entry_points]
+textx_languages =
+    textx = textx.metamodel:textx
 
 [bdist_wheel]
 universal=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,26 +26,26 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
-description-file = README.md
 
 [options]
-packages = textx, textx.scoping
+packages = textx, textx.scoping, textx.cli
 zip_safe = False
-install_requires = Arpeggio>=1.9.0
+install_requires =
+    Arpeggio>=1.9.0
+    click==7.0
 include_package_data = True
 package_dir =
     textx = textx
 setup_requires =
-    setuptools_scm
     wheel
 
 [options.extras_require]
 dev =
-    textx-dev
+    textX-dev
     mkdocs
     mike
+    twine
 test =
-     textx-dev
      flake8
      tox
      jinja2
@@ -54,6 +54,21 @@ test =
      pytest
 
 [options.entry_points]
+console_scripts = 
+    textx = textx.cli:textx
+
+textx_commands = 
+    version = textx.cli.version:version
+    list_languages = textx.cli.discover:list_languages
+    list_generators = textx.cli.discover:list_generators
+    generate = textx.cli.generate:generate
+    check = textx.cli.check:check
+
+textx_generators =
+    textx_dot = textx.generators:metamodel_generate_dot
+    any_dot = textx.generators:model_generate_dot
+    textx_plantuml = textx.generators:metamodel_generate_plantuml
+
 textx_languages =
     textx = textx.metamodel:textx
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ if sys.argv[-1].startswith('publish'):
         os.system("twine upload -r test dist/*")
     else:
         os.system("twine upload dist/*")
+        print("You probably want to also tag the version now:")
+        print("  git tag -a {0} -m 'version {0}'".format(VERSION))
+        print("  git push --tags")
     sys.exit()
 
 setup(version=VERSION)

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,17 @@
 import os
 import sys
 from setuptools import setup
-from pathlib import Path
-this_dir = Path(__file__).absolute().parent
+
+this_dir = os.path.abspath(os.path.dirname(__file__))
+
+VERSIONFILE = os.path.join(this_dir, "textx", "__init__.py")
+VERSION = None
+for line in open(VERSIONFILE, "r").readlines():
+    if line.startswith('__version__'):
+        VERSION = line.split('"')[1]
+
+if not VERSION:
+    raise RuntimeError('No version defined in textx.__init__.py')
 
 if sys.argv[-1].startswith('publish'):
     if os.system("pip list | grep wheel"):
@@ -20,7 +29,4 @@ if sys.argv[-1].startswith('publish'):
         os.system("twine upload dist/*")
     sys.exit()
 
-setup(use_scm_version={
-        "write_to": str(this_dir / "textx" / "version.py"),
-        "write_to_template": '__version__ = "{version}"\n',
-    })
+setup(version=VERSION)

--- a/setup.py
+++ b/setup.py
@@ -2,21 +2,9 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
-import codecs
 from setuptools import setup
-
-VERSIONFILE = "textx/__init__.py"
-VERSION = None
-for line in open(VERSIONFILE, "r").readlines():
-    if line.startswith('__version__'):
-        VERSION = line.split('"')[1]
-
-if not VERSION:
-    raise RuntimeError('No version defined in textx.__init__.py')
-
-README = codecs.open(os.path.join(os.path.dirname(__file__), 'README.md'),
-                     'r', encoding='utf-8').read()
-
+from pathlib import Path
+this_dir = Path(__file__).absolute().parent
 
 if sys.argv[-1].startswith('publish'):
     if os.system("pip list | grep wheel"):
@@ -30,67 +18,9 @@ if sys.argv[-1].startswith('publish'):
         os.system("twine upload -r test dist/*")
     else:
         os.system("twine upload dist/*")
-        print("You probably want to also tag the version now:")
-        print("  git tag -a {0} -m 'version {0}'".format(VERSION))
-        print("  git push --tags")
     sys.exit()
 
-setup(
-    name='textX',
-    version=VERSION,
-    description='Meta-language for DSL implementation inspired by Xtext',
-    long_description=README,
-    long_description_content_type='text/markdown',
-    author='Igor R. Dejanovic',
-    author_email='igor.dejanovic@gmail.com',
-    license='MIT',
-    url='https://github.com/textX/textX',
-    download_url='https://github.com/textX/textX/archive/v%s.tar.gz'
-        % VERSION,
-    packages=["textx", "textx.cli", "textx.scoping"],
-    install_requires=["Arpeggio>=1.9.0", "click==7.0"],
-    tests_require=[
-        'pytest',
-    ],
-    keywords="parser meta-language meta-model language DSL",
-    entry_points={
-        'console_scripts': [
-            'textx = textx.cli:textx'
-        ],
-        'textx_commands': [
-            'version = textx.cli:version',
-            'list_languages = textx.cli.discover:list_languages',
-            'list_generators = textx.cli.discover:list_generators',
-            'generate = textx.cli.generate:generate',
-            'check = textx.cli.check:check'
-        ],
-        'textx_languages': [
-            'textx = textx.metamodel:textx',  # textX meta-language is built-in
-        ],
-        'textx_generators': [
-            'textx_dot = textx.generators:metamodel_generate_dot',
-            'any_dot = textx.generators:model_generate_dot',
-            'textx_plantuml = textx.generators:metamodel_generate_plantuml',
-        ]
-    },
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Information Technology',
-        'Intended Audience :: Science/Research',
-        'Topic :: Software Development :: Interpreters',
-        'Topic :: Software Development :: Compilers',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
-        ]
-
-)
+setup(use_scm_version={
+        "write_to": str(this_dir / "textx" / "version.py"),
+        "write_to_template": '__version__ = "{version}"\n',
+    })

--- a/tests/functional/registration/projects/data_dsl/setup.cfg
+++ b/tests/functional/registration/projects/data_dsl/setup.cfg
@@ -1,0 +1,16 @@
+[metadata]
+name = data_dsl
+version = 1.0.0
+
+[options]
+packages = find:
+install_requires =
+    textX
+    types_dsl
+
+[options.package_data]
+data_dsl = *.tx
+
+[options.entry_points]
+textx_languages =
+    data_dsl = data_dsl:data_dsl 

--- a/tests/functional/registration/projects/data_dsl/setup.py
+++ b/tests/functional/registration/projects/data_dsl/setup.py
@@ -1,13 +1,3 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(name='data_dsl',
-      version='1.0.0',
-      packages=find_packages(),
-      package_data={'': ['*.tx']},
-      install_requires=["textx", "types_dsl"],
-      entry_points={
-        'textx_languages': [
-            'data_dsl = data_dsl:data_dsl',
-          ]
-      },
-      )
+setup()

--- a/tests/functional/registration/projects/flow_codegen/setup.cfg
+++ b/tests/functional/registration/projects/flow_codegen/setup.cfg
@@ -1,0 +1,13 @@
+[metadata]
+name = flow_codegen
+version = 1.0.0
+
+[options]
+packages = find:
+install_requires =
+    textX
+    click
+
+[options.entry_points]
+textx_generators =
+    flow_dsl_plantuml = flow_codegen.generators:flow_pu

--- a/tests/functional/registration/projects/flow_codegen/setup.py
+++ b/tests/functional/registration/projects/flow_codegen/setup.py
@@ -1,13 +1,3 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(name='flow_codegen',
-      version='1.0.0',
-      packages=find_packages(),
-      package_data={'': ['*.tx']},
-      install_requires=["textx", "click"],
-      entry_points={
-          'textx_generators': [
-              'flow_dsl_plantuml=flow_codegen.generators:flow_pu',
-          ]
-      },
-      )
+setup()

--- a/tests/functional/registration/projects/flow_dsl/setup.cfg
+++ b/tests/functional/registration/projects/flow_dsl/setup.cfg
@@ -1,0 +1,15 @@
+[metadata]
+name = flow_dsl
+version = 1.0.0
+
+[options]
+packages = find:
+install_requires =
+    textX
+
+[options.package_data]
+data_dsl = *.tx
+
+[options.entry_points]
+textx_languages =
+    flow_dsl = flow_dsl:flow_dsl 

--- a/tests/functional/registration/projects/flow_dsl/setup.py
+++ b/tests/functional/registration/projects/flow_dsl/setup.py
@@ -1,13 +1,3 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(name='flow_dsl',
-      version='1.0.0',
-      packages=find_packages(),
-      package_data={'': ['*.tx']},
-      install_requires=["textx"],
-      entry_points={
-        'textx_languages': [
-            'flow_dsl = flow_dsl:flow_dsl',
-          ]
-      },
-      )
+setup()

--- a/tests/functional/registration/projects/types_dsl/setup.cfg
+++ b/tests/functional/registration/projects/types_dsl/setup.cfg
@@ -1,0 +1,15 @@
+[metadata]
+name = types_dsl
+version = 1.0.0
+
+[options]
+packages = find:
+install_requires =
+    textX
+
+[options.package_data]
+types_dsl = *.tx
+
+[options.entry_points]
+textx_languages =
+    types_dsl = types_dsl:types_dsl 

--- a/tests/functional/registration/projects/types_dsl/setup.py
+++ b/tests/functional/registration/projects/types_dsl/setup.py
@@ -1,13 +1,3 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(name='types_dsl',
-      version='1.0.0',
-      packages=find_packages(),
-      package_data={'': ['*.tx']},
-      install_requires=["textx"],
-      entry_points={
-        'textx_languages': [
-            'types_dsl = types_dsl:types_dsl',
-        ]
-      },
-      )
+setup()

--- a/tests/functional/subcommands/example_project/setup.cfg
+++ b/tests/functional/subcommands/example_project/setup.cfg
@@ -1,0 +1,13 @@
+[metadata]
+name = textX-subcommand-test
+version = 1.0.0
+
+[options]
+packages = find:
+install_requires =
+    textX
+
+[options.entry_points]
+textx_commands =
+    testcommand = textx_subcommand_test.cli:testcommand
+    testgroup = textx_subcommand_test.cli:create_testgroup

--- a/tests/functional/subcommands/example_project/setup.py
+++ b/tests/functional/subcommands/example_project/setup.py
@@ -2,13 +2,4 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 
-setup(
-    name='textX-subcommand-test',
-    packages=["textx_subcommand_test"],
-    entry_points={
-        'textx_commands': [
-            'testcommand = textx_subcommand_test.cli:testcommand',
-            'testgroup = textx_subcommand_test.cli:create_testgroup'
-        ]
-    }
-)
+setup()

--- a/textx/cli/__init__.py
+++ b/textx/cli/__init__.py
@@ -10,16 +10,6 @@ def textx(ctx, debug):
     ctx.obj = {'debug': debug}
 
 
-def version(textx):
-    @textx.command()
-    def version():
-        """
-        Print version info.
-        """
-        import textx
-        click.echo('textX {}'.format(textx.__version__))
-
-
 def register_textx_subcommands():
     """
     Find and use all textx sub-commands registered through the extension point.

--- a/textx/cli/version.py
+++ b/textx/cli/version.py
@@ -1,0 +1,11 @@
+import click
+
+
+def version(textx):
+    @textx.command()
+    def version():
+        """
+        Print version info.
+        """
+        import textx
+        click.echo('textX {}'.format(textx.__version__))


### PR DESCRIPTION
This is bigger one and thus we'll merge against `next-release` as backward incompatible.

With this rework I'm trying to separate what is needed at development out of the main project. This repo will contain only the core features needed at run-time. The project that will host development features will be [textX-dev](https://github.com/textX/textX-dev). This project contains CLI commands, meta-model exporting functionality etc. 

The benefit is that in run-time, all the user will have to install will be textX and the only dependency will be Arpeggio. No `textx` cli command will be available. If the user install `textX-dev` (or install this repo with `dev` extras, e.g. by `pip install textX[dev]` than it will pull in `textX-dev` will all dependencies needed for development (e.g. click, scaffolding...).

This change will enable us to introduce new dev dependencies without worrying that we will have unnecessary overhead for deployment.

In addition I'm moving project's meta-data from `setup.py` to `setup.cfg`. Also, introducing `setuptools_scm` for managing versions using git history/tags.


## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
