### PR TITLE
Allow passing project root path to GlobalModelRepository

### DIFF
--- a/textx/model.py
+++ b/textx/model.py
@@ -228,7 +228,7 @@ def get_model_parser(top_rule, comments_model, **kwargs):
 
         def get_model_from_file(self, file_name, encoding, debug,
                                 pre_ref_resolution_callback=None,
-                                is_main_model=True):
+                                is_main_model=True, project_root=None):
             """
             Creates model from the parse tree from the previous parse call.
             If file_name is given file will be parsed before model
@@ -240,13 +240,15 @@ def get_model_parser(top_rule, comments_model, **kwargs):
             model = self.get_model_from_str(
                 model_str, file_name=file_name, debug=debug,
                 pre_ref_resolution_callback=pre_ref_resolution_callback,
-                is_main_model=is_main_model, encoding=encoding)
+                is_main_model=is_main_model, encoding=encoding,
+                project_root=project_root)
 
             return model
 
         def get_model_from_str(self, model_str, file_name=None, debug=None,
                                pre_ref_resolution_callback=None,
-                               is_main_model=True, encoding='utf-8'):
+                               is_main_model=True, encoding='utf-8',
+                               project_root=None):
             """
             Parses given string and creates model object graph.
             """
@@ -265,7 +267,8 @@ def get_model_parser(top_rule, comments_model, **kwargs):
                 model = parse_tree_to_objgraph(
                     self, self.parse_tree[0], file_name=file_name,
                     pre_ref_resolution_callback=pre_ref_resolution_callback,
-                    is_main_model=is_main_model, encoding=encoding)
+                    is_main_model=is_main_model, encoding=encoding,
+                    project_root=project_root)
             finally:
                 if debug is not None:
                     self.debug = old_debug_state
@@ -282,7 +285,8 @@ def get_model_parser(top_rule, comments_model, **kwargs):
 
 def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                            pre_ref_resolution_callback=None,
-                           is_main_model=True, encoding='utf-8'):
+                           is_main_model=True, encoding='utf-8',
+                           project_root=None):
     """
     Transforms parse_tree to object graph representing model in a
     new language.
@@ -624,12 +628,13 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
             pass
 
         if pre_ref_resolution_callback:
-            pre_ref_resolution_callback(model)
+            pre_ref_resolution_callback(model, project_root=project_root)
 
         for scope_provider in metamodel.scope_providers.values():
             from textx.scoping import ModelLoader
             if isinstance(scope_provider, ModelLoader):
-                scope_provider.load_models(model, encoding=encoding)
+                scope_provider.load_models(model, encoding=encoding,
+                                           project_root=project_root)
 
         if not is_primitive_type:
             model._tx_reference_resolver = ReferenceResolver(

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -207,9 +207,11 @@ class GlobalModelRepository(object):
                 # all models loaded here get their references resolved from the
                 # root model
                 new_model = the_metamodel.internal_model_from_file(
-                    filename, pre_ref_resolution_callback=lambda
-                    other_model: self.pre_ref_resolution_callback(other_model),
-                    is_main_model=is_main_model, encoding=encoding)
+                    filename,
+                    pre_ref_resolution_callback=\
+                        self.pre_ref_resolution_callback,
+                    is_main_model=is_main_model, encoding=encoding,
+                    project_root=self.project_root)
                 self.all_models.filename_to_model[filename] = new_model
             # print("ADDING {}".format(filename))
             if add_to_local_models:
@@ -254,12 +256,13 @@ class GlobalModelRepository(object):
         # print("UPDATED/ADDED/CACHED {}".format(myfilename))
         return myfilename
 
-    def pre_ref_resolution_callback(self, other_model):
+    def pre_ref_resolution_callback(self, other_model, project_root=None):
         """
         internal: used to store a model after parsing into the repository
 
         Args:
             other_model: the parsed model
+            project_root: root directory where to look for models
 
         Returns:
             nothing
@@ -269,7 +272,7 @@ class GlobalModelRepository(object):
         assert (filename)
         filename = abspath(filename)
         other_model._tx_model_repository = \
-            GlobalModelRepository(self.all_models)
+            GlobalModelRepository(self.all_models, project_root=project_root)
         self.all_models.filename_to_model[filename] = other_model
 
 
@@ -282,7 +285,7 @@ class ModelLoader(object):
     def __init__(self):
         pass
 
-    def load_models(self, model):
+    def load_models(self, model, project_root=None):
         pass
 
 

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -335,7 +335,7 @@ class ImportURI(scoping.ModelLoader):
                         glob_args=self.glob_args, encoding=encoding,
                         add_to_local_models=add_to_local_models)
 
-    def load_models(self, model, encoding='utf-8'):
+    def load_models(self, model, encoding='utf-8', project_root=None):
         from textx.model import get_metamodel
         from textx.scoping import GlobalModelRepository
         # do we already have loaded models (analysis)? No -> check/load them
@@ -343,10 +343,12 @@ class ImportURI(scoping.ModelLoader):
             pass
         else:
             if hasattr(get_metamodel(model), "_tx_model_repository"):
-                model_repository = GlobalModelRepository(get_metamodel(
-                    model)._tx_model_repository.all_models)
+                model_repository = GlobalModelRepository(
+                    get_metamodel(model)._tx_model_repository.all_models,
+                    project_root=project_root)
             else:
-                model_repository = GlobalModelRepository()
+                model_repository = GlobalModelRepository(
+                    project_root=project_root)
             model._tx_model_repository = model_repository
         self._load_referenced_models(model, encoding=encoding)
 
@@ -478,7 +480,7 @@ class GlobalRepo(ImportURI):
         self.models_to_be_added_directly.append(model)
 
     def load_models_in_model_repo(self, global_model_repo=None,
-                                  encoding='utf-8'):
+                                  encoding='utf-8', project_root=None):
         """
         load all registered models (called explicitly from
         the user and not as an automatic activity).
@@ -495,7 +497,8 @@ class GlobalRepo(ImportURI):
         """
         import textx.scoping
         if not global_model_repo:
-            global_model_repo = textx.scoping.GlobalModelRepository()
+            global_model_repo = textx.scoping.GlobalModelRepository(
+                project_root=project_root)
         for filename_pattern in self.filename_pattern_list:
             global_model_repo.load_models_using_filepattern(
                 filename_pattern, model=None, glob_args=self.glob_args,


### PR DESCRIPTION
<!-- Please don't remove/change code review checklist -->

Provides a way to search for models at different location regardless where python process is started (`os.getcwd`).

Related to #239 and #240.

Should we allow passing multiple locations?

- [x] `project_root` param when parsing models (`model_from_str`, `model_from_file`)
- [ ] `project_root` param when parsing meta-models (?)
- [ ] cli `project_root` param

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
