### PR TITLE
Explicitly check for object to be not None rather than rely on truthi…

### DIFF
--- a/tests/functional/test_processors.py
+++ b/tests/functional/test_processors.py
@@ -92,6 +92,37 @@ def test_object_processors():
     assert call_order == [2, 2, 2, 1]
 
 
+def test_object_processor_falsy():
+    """
+    Test that object processors are called for falsy objects.
+    """
+
+    def second_obj_processor(second):
+        second._second_called = True
+
+    obj_processors = {
+        'Second': second_obj_processor,
+        }
+
+    class Second(object):
+        def __init__(self, parent, sec):
+            self.parent = parent
+            self.sec = sec
+            self._second_called = False
+
+        def __len__(self):
+            return 0
+
+    metamodel = metamodel_from_str(grammar, classes=[Second])
+    metamodel.register_obj_processors(obj_processors)
+
+    model_str = 'first 34 45 7 A 45 65 B true C "dfdf"'
+    first = metamodel.model_from_str(model_str)
+
+    for s in first.seconds:
+        assert s._second_called == True
+
+
 def test_object_processor_replace_object():
     """
     Test that what is returned from object processor is value used in the

--- a/tests/functional/test_processors.py
+++ b/tests/functional/test_processors.py
@@ -120,7 +120,7 @@ def test_object_processor_falsy():
     first = metamodel.model_from_str(model_str)
 
     for s in first.seconds:
-        assert s._second_called == True
+        assert s._second_called is True
 
 
 def test_object_processor_replace_object():

--- a/textx/model.py
+++ b/textx/model.py
@@ -510,7 +510,7 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                 assert False
 
         # Collect rules for textx-tools
-        if inst and metamodel.textx_tools_support:
+        if inst is not None and metamodel.textx_tools_support:
             pos = (inst._tx_position, inst._tx_position_end)
             pos_rule_dict[pos] = inst
 
@@ -553,7 +553,7 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                     if attr:
                         if metaattr.mult in many:
                             for idx, obj in enumerate(attr):
-                                if obj:
+                                if obj is not None:
                                     result = call_obj_processors(metamodel,
                                                                  obj,
                                                                  metaattr.cls)

--- a/textx/model.py
+++ b/textx/model.py
@@ -816,7 +816,7 @@ class ReferenceResolver:
                     resolved = default_scope(obj, attr, crossref)
 
                 # Collect cross-references for textx-tools
-                if resolved and not type(resolved) is Postponed:
+                if resolved is not None and not type(resolved) is Postponed:
                     if metamodel.textx_tools_support:
                         self.pos_crossref_list.append(
                             RefRulePosition(
@@ -827,7 +827,7 @@ class ReferenceResolver:
                                 def_pos_start=resolved._tx_position,
                                 def_pos_end=resolved._tx_position_end))
 
-                if not resolved:
+                if resolved is None:
                     # As a fall-back search builtins if given
                     if metamodel.builtins:
                         if crossref.obj_name in metamodel.builtins:
@@ -839,7 +839,7 @@ class ReferenceResolver:
                                 resolved = metamodel.builtins[
                                     crossref.obj_name]
 
-                if not resolved:
+                if resolved is None:
                     line, col = self.parser.pos_to_linecol(crossref.position)
                     raise TextXSemanticError(
                         message='Unknown object "{}" of class "{}"'.format(

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -104,10 +104,7 @@ class PlainName(object):
         else:
             result = _inner_resolve_link_rule_ref(obj_ref.cls,
                                                   obj_ref.obj_name)
-        if result:
-            return result
-
-        return None  # error handled outside
+        return result  # error handled outside
 
 
 class FQN(object):

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -192,7 +192,7 @@ class FQN(object):
 
             for n in fqn_name.split('.'):
                 obj = find_obj(p, n)
-                if obj:
+                if obj is not None:
                     if type(obj) is Postponed:
                         return obj
                     p = obj


### PR DESCRIPTION
…ness

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).

I found a few places in the code where an if condition relies on the truthiness of the corresponding object, this may lead to bugs when a user class object is falsy, most likely because it defines `__len__` to be 0. The test case I added tests one of these instances.

[commit messages]: https://chris.beams.io/posts/git-commit/