### PR TITLE
Msch pre init proxy

### DIFF
--- a/tests/functional/test_user_class_attrs_frozen.py
+++ b/tests/functional/test_user_class_attrs_frozen.py
@@ -1,0 +1,51 @@
+from __future__ import unicode_literals
+import pytest  # noqa
+from textx import metamodel_from_str
+
+grammar = """
+Document:
+    a=A
+    b=B
+;
+A:
+    'A' name=ID
+;
+B:
+    'B' 'a' '=' a=[A]
+;
+"""
+
+
+@pytest.mark.parametrize('frozen', [False, True])
+def test_user_class_attrs(frozen):
+    attr = pytest.importorskip('attr')
+    """
+    User supplied meta class.
+    """
+    @attr.s(frozen=frozen)
+    class Point(object):
+        "User class."
+        parent = attr.ib()
+        name = attr.ib()
+        x = attr.ib()
+        y = attr.ib()
+
+    modelstr = """
+    A something
+    B a=something
+    """
+
+    @attr.s()
+    class A(object):
+        parent = attr.ib()
+        name = attr.ib()
+
+    @attr.s(frozen=frozen)
+    class B(object):
+        parent = attr.ib()
+        a = attr.ib()
+
+    mm = metamodel_from_str(grammar, classes=[A, B],
+                            auto_init_attributes=False)
+    model = mm.model_from_str(modelstr)
+    assert model.b.a == model.a

--- a/tests/functional/test_user_class_with_slots.py
+++ b/tests/functional/test_user_class_with_slots.py
@@ -1,0 +1,48 @@
+from __future__ import unicode_literals
+import pytest  # noqa
+from textx import metamodel_from_str
+
+grammar = """
+Shape:
+    'shape'
+    points+=Point
+    'end'
+;
+Point:
+    'point' x=INT y=INT
+;
+"""
+
+
+def test_user_class_with_slots():
+    """
+    User supplied meta class.
+    """
+    class Point(object):
+        "User class."
+        __slots__ = ['parent', 'x', 'y']
+
+        def __init__(self, parent, x, y):
+            self.parent = parent
+            self.x = x
+            self.y = y
+
+    modelstr = """
+    shape
+    point 34 45
+    point 12 23
+    end
+    """
+
+    mm = metamodel_from_str(grammar, classes=[Point],
+                            auto_init_attributes=False)
+    model = mm.model_from_str(modelstr)
+    # Test that user class is instantiated
+    point = model.points[0]
+
+    assert type(point).__name__ == "Point"
+    assert type(point) is Point
+
+    assert len(model.points) == 2
+    assert point.x == 34
+    assert point.y == 45

--- a/tests/functional/test_user_classes.py
+++ b/tests/functional/test_user_classes.py
@@ -11,7 +11,7 @@ First:
 ;
 
 Second:
-    INT|STRING
+    sec=INT|STRING
 ;
 
 """
@@ -21,6 +21,7 @@ def test_user_class():
     """
     User supplied meta class.
     """
+
     class First(object):
         "User class."
         def __init__(self, seconds, a, b, c):
@@ -33,6 +34,16 @@ def test_user_class():
             self.b = b
             self.c = c
 
+            for second in self.seconds:
+                # Make sure seconds have already been instantiated
+                assert hasattr(second, 'sec') and isinstance(second.sec, int)
+
+    class Second(object):
+        "User class"
+        def __init__(self, parent, sec):
+            self.parent = parent
+            self.sec = sec
+
     modelstr = """
     first 34 45 65 "sdf" 45
     """
@@ -43,7 +54,7 @@ def test_user_class():
     assert type(model).__name__ == "First"
     assert type(model) is not First
 
-    mm = metamodel_from_str(grammar, classes=[First])
+    mm = metamodel_from_str(grammar, classes=[First, Second])
     model = mm.model_from_str(modelstr)
     # Test that user class is instantiated
     assert type(model).__name__ == "First"

--- a/tests/functional/test_user_classes_init_order.py
+++ b/tests/functional/test_user_classes_init_order.py
@@ -1,0 +1,45 @@
+from __future__ import unicode_literals
+import pytest  # noqa
+from textx import metamodel_from_str
+
+grammar = """
+First:
+    'first' seconds+=Second
+;
+
+Second:
+    sec=INT
+;
+"""
+
+
+def test_user_class_init_order():
+    """
+    User supplied meta class.
+    """
+
+    init_order = []
+
+    class First(object):
+        "User class."
+        def __init__(self, seconds):
+            "Constructor must be without parameters."
+            self.seconds = seconds
+            init_order.append(self)
+
+    class Second(object):
+        "User class"
+        def __init__(self, parent, sec):
+            self.parent = parent
+            self.sec = sec
+            init_order.append(self)
+
+    modelstr = """
+    first 0 1 2
+    """
+
+    mm = metamodel_from_str(grammar, classes=[First, Second])
+    first = mm.model_from_str(modelstr)
+
+    expected_init_order = first.seconds + [first]
+    assert init_order == expected_init_order

--- a/tests/functional/test_wrap_attrs.py
+++ b/tests/functional/test_wrap_attrs.py
@@ -1,0 +1,25 @@
+from pytest import raises
+
+from textx.metamodel import wrap_attrs, AttrsWrapper, WrappingError
+
+
+def test_wrap_attrs():
+    class TestClass(object):
+        _tx_attrs = []
+
+    obj = TestClass()
+    wrapped = wrap_attrs(obj)
+    assert isinstance(wrapped, AttrsWrapper)
+
+    with raises(WrappingError):
+        type(wrapped) == object
+
+    with raises(WrappingError):
+        object == type(wrapped)
+
+    with raises(WrappingError):
+        wrapped.__class__
+
+    with raises(WrappingError):
+        wrapped.__dict__
+

--- a/textx/export.py
+++ b/textx/export.py
@@ -5,6 +5,7 @@ Export of textX based models and metamodels to dot file.
 from __future__ import unicode_literals
 from arpeggio import Match, OrderedChoice, Sequence, OneOrMore, ZeroOrMore,\
     Optional
+from textx import textx_isinstance
 from textx.const import MULT_ZEROORMORE, MULT_ONEORMORE, MULT_ONE, \
     RULE_ABSTRACT, RULE_COMMON, RULE_MATCH
 from textx.lang import PRIMITIVE_PYTHON_TYPES, BASE_TYPE_NAMES, ALL_TYPE_NAMES
@@ -50,17 +51,17 @@ def dot_match_str(cls, other_match_rules=None):
                 return s.rule_name
 
         visited.add(s)
-        if isinstance(s, Match):
+        if textx_isinstance(s, Match):
             result = text(s)
-        elif isinstance(s, OrderedChoice):
+        elif textx_isinstance(s, OrderedChoice):
             result = "|".join([r(x) for x in s.nodes])
-        elif isinstance(s, Sequence):
+        elif textx_isinstance(s, Sequence):
             result = " ".join([r(x) for x in s.nodes])
-        elif isinstance(s, ZeroOrMore):
+        elif textx_isinstance(s, ZeroOrMore):
             result = "({})*".format(r(s.nodes[0]))
-        elif isinstance(s, OneOrMore):
+        elif textx_isinstance(s, OneOrMore):
             result = "({})+".format(r(s.nodes[0]))
-        elif isinstance(s, Optional):
+        elif textx_isinstance(s, Optional):
             result = "{}?".format(r(s.nodes[0]))
         else:
             # breakpoint()
@@ -78,12 +79,12 @@ def dot_match_str(cls, other_match_rules=None):
         visited = set()
         if other_match_rules is None:
             other_match_rules = set()
-        if not isinstance(e, Match):
+        if not textx_isinstance(e, Match):
             visited.add(e)
-        if isinstance(e, OrderedChoice):
+        if textx_isinstance(e, OrderedChoice):
             mstr = "|".join([r(x) for x in e.nodes
                              if x.rule_name in BASE_TYPE_NAMES or not x.root])
-        elif isinstance(e, Sequence):
+        elif textx_isinstance(e, Sequence):
             mstr = " ".join([r(x) for x in e.nodes])
         else:
             mstr = r(e)

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -540,7 +540,8 @@ class TextXVisitor(PTNodeVisitor):
             cls = self.metamodel.user_classes[rule_name]
 
             # Initialize special attributes
-            self.metamodel._init_class(cls, None, node.position)
+            self.metamodel._init_class(cls, None, node.position,
+                                       external_attributes=True)
         else:
             # Create class to collect attributes. At this time PEG rule
             # is not known.

--- a/textx/metamodel.py
+++ b/textx/metamodel.py
@@ -438,6 +438,7 @@ class TextXMetaModel(DebugPrinter):
 
         if root:
             self.rootcls = cls
+            
 
         if external_attributes:
             cls._tx_obj_attrs = {}
@@ -469,7 +470,7 @@ class TextXMetaModel(DebugPrinter):
                 # Instantiate base python type
                 if self.auto_init_attributes:
                     _setattr(obj, attr.name,
-                             python_type(attr.cls.__name__)())
+                            python_type(attr.cls.__name__)())
                 else:
                     # See https://github.com/textX/textX/issues/11
                     if attr.bool_assignment:

--- a/textx/metamodel.py
+++ b/textx/metamodel.py
@@ -438,7 +438,6 @@ class TextXMetaModel(DebugPrinter):
 
         if root:
             self.rootcls = cls
-            
 
         if external_attributes:
             cls._tx_obj_attrs = {}
@@ -470,7 +469,7 @@ class TextXMetaModel(DebugPrinter):
                 # Instantiate base python type
                 if self.auto_init_attributes:
                     _setattr(obj, attr.name,
-                            python_type(attr.cls.__name__)())
+                                 python_type(attr.cls.__name__)())
                 else:
                     # See https://github.com/textX/textX/issues/11
                     if attr.bool_assignment:

--- a/textx/metamodel.py
+++ b/textx/metamodel.py
@@ -89,6 +89,30 @@ class MetaAttr(object):
         self.position = position
 
 
+def _setattr(obj, name, value):
+    if hasattr(obj.__class__, '_tx_obj_attrs')\
+            and id(obj) in obj.__class__._tx_obj_attrs:
+        obj.__class__._tx_obj_attrs[id(obj)][name] = value
+    else:
+        setattr(obj, name, value)
+
+
+def _getattr(obj, name, *args):
+    if hasattr(obj.__class__, '_tx_obj_attrs')\
+            and id(obj) in obj.__class__._tx_obj_attrs:
+        return obj.__class__._tx_obj_attrs[id(obj)][name]
+    else:
+        return getattr(obj, name, *args)
+
+
+def _hasattr(obj, name):
+    if hasattr(obj.__class__, '_tx_obj_attrs')\
+            and id(obj) in obj.__class__._tx_obj_attrs:
+        return name in obj.__class__._tx_obj_attrs[id(obj)]
+    else:
+        return hasattr(obj, name)
+
+
 class TextXMetaModel(DebugPrinter):
     """
     Meta-model contains all information about language abstract syntax.
@@ -379,7 +403,8 @@ class TextXMetaModel(DebugPrinter):
         return cls
 
     def _init_class(self, cls, peg_rule, position, position_end=None,
-                    inherits=None, root=False, rule_type=RULE_MATCH):
+                    inherits=None, root=False, rule_type=RULE_MATCH,
+                    external_attributes=False):
         """
         Setup meta-class special attributes, namespaces etc. This is called
         both for textX created classes as well as user classes.
@@ -414,6 +439,9 @@ class TextXMetaModel(DebugPrinter):
         if root:
             self.rootcls = cls
 
+        if external_attributes:
+            cls._tx_obj_attrs = {}
+
     def _cls_fqn(self, cls):
         """
         Returns fully qualified name for the class based on current namespace
@@ -430,39 +458,33 @@ class TextXMetaModel(DebugPrinter):
         Initialize obj attributes.
         Args:
             obj(object): A python object to set attributes to.
-            user(bool): If this object is a user object mangle attribute names.
+            user(bool): If this object is a user object store attributes
+                outside the object.
         """
         for attr in obj.__class__._tx_attrs.values():
-
-            if user:
-                # Mangle name to prvent name clashing
-                attr_name = "_txa_%s" % attr.name
-            else:
-                attr_name = attr.name
-
             if attr.mult in [MULT_ZEROORMORE, MULT_ONEORMORE]:
                 # list
-                setattr(obj, attr_name, [])
+                _setattr(obj, attr.name, [])
             elif attr.cls.__name__ in BASE_TYPE_NAMES:
                 # Instantiate base python type
                 if self.auto_init_attributes:
-                    setattr(obj, attr_name,
-                            python_type(attr.cls.__name__)())
+                    _setattr(obj, attr.name,
+                             python_type(attr.cls.__name__)())
                 else:
                     # See https://github.com/textX/textX/issues/11
                     if attr.bool_assignment:
                         # Only ?= assignments shall have default
                         # value of False.
-                        setattr(obj, attr_name, False)
+                        _setattr(obj, attr.name, False)
                     else:
                         # Set base type attribute to None initially
                         # in order to be able to detect if an optional
                         # values are given in the model. Default values
                         # can be specified using object processors.
-                        setattr(obj, attr_name, None)
+                        _setattr(obj, attr.name, None)
             else:
                 # Reference to other obj
-                setattr(obj, attr_name, None)
+                _setattr(obj, attr.name, None)
 
     def _new_cls_attr(self, clazz, name, cls=None, mult=MULT_ONE, cont=True,
                       ref=False, bool_assignment=False, position=0):

--- a/textx/metamodel.py
+++ b/textx/metamodel.py
@@ -8,7 +8,7 @@ import sys
 from abc import ABCMeta
 from os.path import join, abspath, dirname
 from collections import OrderedDict, MutableMapping
-from typing import MutableSequence, Protocol, Generic
+from typing import MutableSequence
 
 import six
 from arpeggio import DebugPrinter
@@ -179,8 +179,20 @@ class WrapperMeta(ABCMeta):
         self.__is_wrapped__ = True
 
     def __eq__(self, other):
-        if other in (Generic, Protocol):
-            return False
+        try:
+            from typing import Generic
+        except ImportError:
+            pass
+        else:
+            if other == Generic:
+                return False
+        try:
+            from typing import Protocol
+        except ImportError:
+            pass
+        else:
+            if other == Protocol:
+                return False
         raise WrappingError("A wrapper class should never be compared to "
                             "another class.")
 

--- a/textx/model.py
+++ b/textx/model.py
@@ -683,26 +683,6 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                             parser.dprint(traceback.print_exc())
                             raise e
 
-                for m in models:
-                    for obj in get_children(
-                            lambda x:
-                            hasattr(x.__class__, '_tx_obj_attrs'), m):
-                        # If the the attributes to the class have been
-                        # collected in _tx_obj_attrs we need to do a proper
-                        # initialization at this point.
-                        try:
-                            # Get the attributes which have been collected
-                            # in metamodel.obj and remove them from this dict.
-                            attrs = obj.__class__._tx_obj_attrs.pop(
-                                id(obj))
-                            obj.__init__(**attrs)
-                        except TypeError as e:
-                            # Add class name information in case of wrong
-                            # constructor parameters
-                            e.args += ("for class %s" %
-                                       obj.__class__.__name__,)
-                            parser.dprint(traceback.print_exc())
-                            raise e
 
                 # cleanup
                 for m in models:

--- a/textx/model.py
+++ b/textx/model.py
@@ -700,6 +700,27 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                             parser.dprint("CALLING OBJECT PROCESSORS")
                         call_obj_processors(m._tx_metamodel, m)
 
+                for m in models:
+                    for obj in get_children(
+                            lambda x:
+                            hasattr(x.__class__, '_tx_obj_attrs'), m):
+                        # If the the attributes to the class have been
+                        # collected in _tx_obj_attrs we need to do a proper
+                        # initialization at this point.
+                        try:
+                            # Get the attributes which have been collected
+                            # in metamodel.obj and remove them from this dict.
+                            attrs = obj.__class__._tx_obj_attrs.pop(
+                                id(obj))
+                            obj.__init__(**attrs)
+                        except TypeError as e:
+                            # Add class name information in case of wrong
+                            # constructor parameters
+                            e.args += ("for class %s" %
+                                       obj.__class__.__name__,)
+                            parser.dprint(traceback.print_exc())
+                            raise e
+
             except BaseException as e:
                 # remove all processed models from (global) repo (if present)
                 # (remove all of them, not only the model with errors,

--- a/textx/model.py
+++ b/textx/model.py
@@ -683,23 +683,6 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                             parser.dprint(traceback.print_exc())
                             raise e
 
-                # cleanup
-                for m in models:
-                    _end_model_construction(m)
-
-                # final check that everything went ok
-                for m in models:
-                    assert 0 == len(get_children_of_type(
-                        Postponed.__class__, m))
-
-                    # We have model loaded and all link resolved
-                    # So we shall do a depth-first call of object
-                    # processors if any processor is defined.
-                    if m._tx_metamodel.obj_processors:
-                        if parser.debug:
-                            parser.dprint("CALLING OBJECT PROCESSORS")
-                        call_obj_processors(m._tx_metamodel, m)
-
                 for m in models:
                     for obj in get_children(
                             lambda x:
@@ -720,6 +703,23 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                                        obj.__class__.__name__,)
                             parser.dprint(traceback.print_exc())
                             raise e
+
+                # cleanup
+                for m in models:
+                    _end_model_construction(m)
+
+                # final check that everything went ok
+                for m in models:
+                    assert 0 == len(get_children_of_type(
+                        Postponed.__class__, m))
+
+                    # We have model loaded and all link resolved
+                    # So we shall do a depth-first call of object
+                    # processors if any processor is defined.
+                    if m._tx_metamodel.obj_processors:
+                        if parser.debug:
+                            parser.dprint("CALLING OBJECT PROCESSORS")
+                        call_obj_processors(m._tx_metamodel, m)
 
             except BaseException as e:
                 # remove all processed models from (global) repo (if present)

--- a/textx/model.py
+++ b/textx/model.py
@@ -12,6 +12,7 @@ from textx.const import MULT_OPTIONAL, MULT_ONE, MULT_ONEORMORE, \
     MULT_ZEROORMORE, RULE_ABSTRACT, RULE_MATCH, MULT_ASSIGN_ERROR, \
     UNKNOWN_OBJ_ERROR
 from textx.lang import PRIMITIVE_PYTHON_TYPES
+from textx.metamodel import _setattr, _getattr, _hasattr
 from textx.scoping import Postponed, remove_models_from_repositories, \
     get_included_models
 from textx.scoping.providers import PlainName as DefaultScopeProvider
@@ -30,8 +31,8 @@ def get_model(obj):
     Finds model root element for the given object.
     """
     p = obj
-    while hasattr(p, 'parent'):
-        p = p.parent
+    while _hasattr(p, 'parent'):
+        p = _getattr(p, 'parent')
     return p
 
 
@@ -56,13 +57,13 @@ def get_parent_of_type(typ, obj):
     if type(typ) is not text:
         typ = typ.__name__
 
-    while hasattr(obj, 'parent'):
-        obj = obj.parent
+    while _hasattr(obj, 'parent'):
+        obj = _getattr(obj, 'parent')
         if obj.__class__.__name__ == typ:
             return obj
 
 
-def get_children(decider, root):
+def get_children(decider, root, children_first=False):
     """
     Returns a list of all model elements of type 'typ' starting from model
     element 'root'. The search process will follow containment links only.
@@ -72,33 +73,44 @@ def get_children(decider, root):
         decider(obj): a callable returning True if the object is of interest.
         root (model object): Python model object which is the start of the
             search process.
+        children_first (bool): a flag indicating whether children will be
+            returned before their parents (default=False)
     """
     collected = []
+    collected_ids = set()
 
     def follow(elem):
 
-        if elem in collected:
+        if id(elem) in collected_ids:
+            # Use id to avoid relying on __eq__ of user class
             return
 
         # Use meta-model to search for all contained child elements.
         cls = elem.__class__
 
-        if hasattr(cls, '_tx_attrs') and decider(elem):
-            collected.append(elem)
+        if not children_first:
+            if hasattr(cls, '_tx_attrs') and decider(elem):
+                collected.append(elem)
+                collected_ids.add(id(elem))
 
         if hasattr(cls, '_tx_attrs'):
             for attr_name, attr in cls._tx_attrs.items():
                 # Follow only attributes with containment semantics
                 if attr.cont:
                     if attr.mult in (MULT_ONE, MULT_OPTIONAL):
-                        new_elem = getattr(elem, attr_name)
+                        new_elem = _getattr(elem, attr_name)
                         if new_elem:
                             follow(new_elem)
                     else:
-                        new_elem_list = getattr(elem, attr_name)
+                        new_elem_list = _getattr(elem, attr_name)
                         if new_elem_list:
                             for new_elem in new_elem_list:
                                 follow(new_elem)
+
+        if children_first:
+            if hasattr(cls, '_tx_attrs') and decider(elem):
+                collected.append(elem)
+                collected_ids.add(id(elem))
 
     follow(root)
     return collected
@@ -368,6 +380,7 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                 # At this point we need object to be allocated
                 # So that nested object get correct reference
                 inst = user_class.__new__(user_class)
+                user_class._tx_obj_attrs[id(inst)] = {}
 
                 # Initialize object attributes for user class
                 parser.metamodel._init_obj_attrs(inst, user=True)
@@ -382,8 +395,12 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
             # Collect attributes directly on meta-class instance
             obj_attrs = inst
 
-            inst._tx_position = node.position
-            inst._tx_position_end = node.position_end
+            try:
+                inst._tx_position = node.position
+                inst._tx_position_end = node.position_end
+            except AttributeError:
+                # Skip if class doesn't allow to set these attributes
+                pass
 
             # Push real obj. and dummy attr obj on the instance stack
             parser._inst_stack.append((inst, obj_attrs))
@@ -398,39 +415,16 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
 
             # If this object is nested add 'parent' reference
             if parser._inst_stack:
-                if node.rule_name in metamodel.user_classes:
-                    obj_attrs._txa_parent = parser._inst_stack[-1][0]
-                else:
-                    obj_attrs.parent = parser._inst_stack[-1][0]
-
-            # If the class is user supplied we need to do
-            # a proper initialization at this point.
-            if node.rule_name in metamodel.user_classes:
-                try:
-                    # Get only attributes defined by the grammar as well
-                    # as `parent` if exists
-                    attrs = {}
-                    if hasattr(obj_attrs, '_txa_parent'):
-                        attrs['parent'] = obj_attrs._txa_parent
-                        del obj_attrs._txa_parent
-                    for a in obj_attrs.__class__._tx_attrs:
-                        attrs[a] = getattr(obj_attrs, "_txa_%s" % a)
-                        delattr(obj_attrs, "_txa_%s" % a)
-                    inst.__init__(**attrs)
-                except TypeError as e:
-                    # Add class name information in case of
-                    # wrong constructor parameters
-                    e.args += ("for class %s" %
-                               inst.__class__.__name__,)
-                    parser.dprint(traceback.print_exc())
-                    raise e
+                _setattr(
+                    obj_attrs, 'parent', parser._inst_stack[-1][0])
 
             # Special case for 'name' attrib. It is used for cross-referencing
-            if hasattr(inst, 'name') and inst.name:
+            if _hasattr(inst, 'name') and _getattr(inst, 'name'):
                 # Objects of each class are in its own namespace
                 if not id(inst.__class__) in parser._instances:
                     parser._instances[id(inst.__class__)] = {}
-                parser._instances[id(inst.__class__)][inst.name] = inst
+                parser._instances[id(inst.__class__)][_getattr(inst, 'name')]\
+                    = inst
 
             if parser.debug:
                 parser.dprint("LEAVING INSTANCE {}".format(node.rule_name))
@@ -443,22 +437,15 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
             cls = type(model_obj)
             metaattr = cls._tx_attrs[attr_name]
 
-            # Mangle attribute name to prevent name clashing with property
-            # setters on user classes
-            if cls.__name__ in metamodel.user_classes:
-                txa_attr_name = "_txa_%s" % attr_name
-            else:
-                txa_attr_name = attr_name
-
             if parser.debug:
                 parser.dprint('Handling assignment: {} {}...'
-                              .format(op, txa_attr_name))
+                              .format(op, attr_name))
 
             if op == 'optional':
-                setattr(obj_attr, txa_attr_name, True)
+                _setattr(obj_attr, attr_name, True)
 
             elif op == 'plain':
-                attr_value = getattr(obj_attr, txa_attr_name)
+                attr_value = _getattr(obj_attr, attr_name)
                 if attr_value and type(attr_value) is not list:
                     fmt = "Multiple assignments to attribute {} at {}"
                     raise TextXSemanticError(
@@ -479,7 +466,7 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                 if type(attr_value) is list:
                     attr_value.append(value)
                 else:
-                    setattr(obj_attr, txa_attr_name, value)
+                    _setattr(obj_attr, attr_name, value)
 
             elif op in ['list', 'oneormore', 'zeroormore']:
                 for n in node:
@@ -501,10 +488,10 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                                                       value))
                             continue
 
-                        if not hasattr(obj_attr, txa_attr_name) or \
-                                getattr(obj_attr, txa_attr_name) is None:
-                            setattr(obj_attr, txa_attr_name, [])
-                        getattr(obj_attr, txa_attr_name).append(value)
+                        if not _hasattr(obj_attr, attr_name) or \
+                                _getattr(obj_attr, attr_name) is None:
+                            _setattr(obj_attr, attr_name, [])
+                        _getattr(obj_attr, attr_name).append(value)
             else:
                 # This shouldn't happen
                 assert False
@@ -549,7 +536,7 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
             for metaattr in current_metaclass_of_obj._tx_attrs.values():
                 # If attribute is base type or containment reference go down
                 if metaattr.cont:
-                    attr = getattr(model_obj, metaattr.name)
+                    attr = _getattr(model_obj, metaattr.name)
                     if attr:
                         if metaattr.mult in many:
                             for idx, obj in enumerate(attr):
@@ -563,7 +550,8 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                             result = call_obj_processors(metamodel,
                                                          attr, metaattr.cls)
                             if result is not None:
-                                setattr(model_obj, metaattr.name, result)
+                                _setattr(
+                                    model_obj, metaattr.name, result)
 
             # call obj_proc of the current meta_class if type == RULE_ABSTRACT
             if current_metaclass_of_obj._tx_fqn !=\
@@ -671,6 +659,29 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                 for m in models:
                     # TODO: what does this check?
                     assert not m._tx_reference_resolver.parser._inst_stack
+
+                for m in models:
+                    for obj in get_children(
+                        lambda x: hasattr(x.__class__, '_tx_obj_attrs'),
+                        m,
+                        children_first=True,
+                    ):
+                        # If the the attributes to the class have been
+                        # collected in _tx_obj_attrs we need to do a proper
+                        # initialization at this point.
+                        try:
+                            # Get the attributes which have been collected
+                            # in metamodel.obj and remove them from this dict.
+                            attrs = obj.__class__._tx_obj_attrs.pop(
+                                id(obj))
+                            obj.__init__(**attrs)
+                        except TypeError as e:
+                            # Add class name information in case of wrong
+                            # constructor parameters
+                            e.args += ("for class %s" %
+                                       obj.__class__.__name__,)
+                            parser.dprint(traceback.print_exc())
+                            raise e
 
                 # cleanup
                 for m in models:
@@ -801,7 +812,7 @@ class ReferenceResolver:
         default_scope = DefaultScopeProvider()
         for obj, attr, crossref in current_crossrefs:
             if (get_model(obj) == self.model):
-                attr_value = getattr(obj, attr.name)
+                attr_value = _getattr(obj, attr.name)
                 attr_refs = [obj.__class__.__name__ + "." + attr.name,
                              "*." + attr.name, obj.__class__.__name__ + ".*",
                              "*.*"]
@@ -856,7 +867,7 @@ class ReferenceResolver:
                     if attr.mult in [MULT_ONEORMORE, MULT_ZEROORMORE]:
                         attr_value.append(resolved)
                     else:
-                        setattr(obj, attr.name, resolved)
+                        _setattr(obj, attr.name, resolved)
             else:  # crossref not in model
                 new_crossrefs.append((obj, attr, crossref))
         # -------------------------

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -8,6 +8,7 @@
 from os.path import dirname, abspath, join
 from textx.exceptions import TextXSemanticError
 import textx.scoping as scoping
+from textx.metamodel import _hasattr, _getattr
 from textx.scoping import Postponed
 
 """
@@ -90,7 +91,7 @@ class PlainName(object):
             from textx import textx_isinstance
             result_lst = get_children(
                 lambda x:
-                hasattr(x, "name") and x.name == obj_ref.obj_name
+                _hasattr(x, "name") and _getattr(x, "name") == obj_ref.obj_name
                 and textx_isinstance(x, obj_ref.cls), get_model(obj))
             if len(result_lst) == 1:
                 result = result_lst[0]
@@ -182,11 +183,12 @@ class FQN(object):
                     obj = getattr(parent, attr)
                     if isinstance(obj, (list, tuple)):
                         for innerobj in obj:
-                            if hasattr(innerobj, "name") \
-                                    and innerobj.name == name:
+                            if _hasattr(innerobj, "name") \
+                                    and _getattr(innerobj, "name") == name:
                                 return innerobj
                     else:
-                        if hasattr(obj, "name") and obj.name == name:
+                        if _hasattr(obj, "name") \
+                                and _getattr(obj, "name") == name:
                             return obj
                 return None
 
@@ -222,8 +224,8 @@ class FQN(object):
             ret = _find_obj_fqn(p, name, cls)
             if ret:
                 return ret
-            while hasattr(p, "parent"):
-                p = p.parent
+            while _hasattr(p, "parent"):
+                p = _getattr(p, "parent")
                 ret = _find_obj_fqn(p, name, cls)
                 if ret:
                     return ret
@@ -307,8 +309,9 @@ class ImportURI(scoping.ModelLoader):
             if self.importURI_to_scope_name is not None:
                 obj.name = self.importURI_to_scope_name(obj)
                 # print("setting name to {}".format(obj.name))
-            if hasattr(obj, "name"):
-                if obj.name is not None and obj.name != "":
+            if _hasattr(obj, "name"):
+                if _getattr(obj, "name") is not None \
+                        and _getattr(obj, "name") != "":
                     add_to_local_models = not self.importAs
 
             visited.append(obj)

--- a/textx/scoping/tools.py
+++ b/textx/scoping/tools.py
@@ -5,6 +5,7 @@
 # License: MIT License
 #######################################################################
 from textx import get_children, get_model
+from textx.metamodel import _getattr
 import re
 
 
@@ -208,7 +209,7 @@ def resolve_model_path(obj, dot_separated_name,
         else:
             return None
     else:
-        next_obj = getattr(obj, names[0])
+        next_obj = _getattr(obj, names[0])
         if needs_to_be_resolved(obj, names[0]):
             return Postponed()
         elif next_obj is None:


### PR DESCRIPTION
<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/

I created a proxy based API for the `_(get|set|has)attr` methods. You can wrap an object which will give you a proxy object which you can read from and write to using the normal syntax `obj.attr`, which gets translated behind the scenes into calls to `_(get|set|has)attr`. Any objects that get returned will equally be wrapped, so `first.second.third` works fine. If the attribute is a list, tuple, or dictionary a special class is used for wrapping in order to implement the full interfaces for these objects. Things that don't work for these wrapped objects are `type(obj)` and `obj.__class__` (use `get_attrs_class(obj)` instead), `obj.__dict__` (use `get_attrs_dict(obj)` instead), as well as `isinstance(obj, something)` (use `textx_isinstance(obj, something)` instead, which has expanded functionality).

I noticed that `textx_isinstance` was often imported locally, and I am unsure if I handled this correct in the instances where I added it. I also didn't check if this was necessary in every instance where I replaced `isinstance` with `textx_isinstance`.

@goto40 @igordejanovic, I would love to hear your feedback