### PR TITLE
Postponed userobj init with instrumented user classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ please take a look at related PRs and issues and see if the change affects you.
   
 ### Changed
 
+  - User classes can now be immutable (e.g. `attr.frozen`) or can use
+    `__slots__`. Thanks markusschmaus@GitHub ([#256])
   - Cleanup of setup configuration and install scripts [#231]
   - Dot/PlantUML rendering of meta-models: remove rendering of base types,
     improve rendering of required/optional, render match rules as a single
@@ -445,6 +447,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#256]: https://github.com/textX/textX/pull/256
 [#235]: https://github.com/textX/textX/pull/235
 [#234]: https://github.com/textX/textX/pull/234
 [#233]: https://github.com/textX/textX/pull/233

--- a/docs/tutorials/entity/srcgen.py
+++ b/docs/tutorials/entity/srcgen.py
@@ -20,8 +20,8 @@ def get_entity_mm():
     Builds and returns a meta-model for Entity language.
     """
     type_builtins = {
-            'integer': SimpleType(None, 'integer'),
-            'string': SimpleType(None, 'string')
+        'integer': SimpleType(None, 'integer'),
+        'string': SimpleType(None, 'string')
     }
     entity_mm = metamodel_from_file(join(this_folder, 'entity.tx'),
                                     classes=[SimpleType],
@@ -40,8 +40,8 @@ def main(debug=False):
         Maps type names from SimpleType to Java.
         """
         return {
-                'integer': 'int',
-                'string': 'String'
+            'integer': 'int',
+            'string': 'String'
         }.get(s.name, s.name)
 
     # Create output folder

--- a/examples/Entity/entity_codegen.py
+++ b/examples/Entity/entity_codegen.py
@@ -22,8 +22,8 @@ def main(debug=False):
         Maps type names from PrimitiveType to Java.
         """
         return {
-                'integer': 'int',
-                'string': 'String'
+            'integer': 'int',
+            'string': 'String'
         }.get(s.name, s.name)
 
     # Create output folder

--- a/examples/Entity/entity_test.py
+++ b/examples/Entity/entity_test.py
@@ -31,8 +31,8 @@ def get_entity_mm(debug=False):
     # Each model will have this simple types during reference resolving but
     # these will not be a part of `types` list of EntityModel.
     type_builtins = {
-            'integer': SimpleType(None, 'integer'),
-            'string': SimpleType(None, 'string')
+        'integer': SimpleType(None, 'integer'),
+        'string': SimpleType(None, 'string')
     }
     entity_mm = metamodel_from_file(join(this_folder, 'entity.tx'),
                                     classes=[SimpleType],

--- a/examples/StateMachine/state_machine.py
+++ b/examples/StateMachine/state_machine.py
@@ -54,7 +54,7 @@ class StateMachine(object):
                 if event == 'q':
                     return
                 event = int(event)
-                event = self.model.events[event-1]
+                event = self.model.events[event - 1]
             except Exception:
                 print('Invalid input')
 

--- a/examples/expression/calc_isinstance.py
+++ b/examples/expression/calc_isinstance.py
@@ -60,7 +60,7 @@ def main(debug=False):
 
     def assertIs(x, rule):
         assert _is(x, rule), 'Unexpected object "{}" to rule "{}"'\
-                    .format(x, type(x), rule)
+            .format(x, rule)
 
     def evaluate(x):
 
@@ -115,7 +115,7 @@ def main(debug=False):
 
         else:
             assert False, 'Unexpected object "{}" of type "{}"'\
-                    .format(x, type(x))
+                .format(x, type(x))
 
     result = evaluate(model)
 

--- a/examples/render_all_grammars/render_all_grammars.py
+++ b/examples/render_all_grammars/render_all_grammars.py
@@ -34,8 +34,8 @@ def main(path=None, debug=False, reportfilename=None):
             destpath = join(dirname(reportfilename), "pu")
             if not exists(destpath):
                 os.mkdir(destpath)
-            dest_pu = join(destpath, outfname_base+".pu")
-            dest_pu_png = join(destpath, outfname_base+".png")
+            dest_pu = join(destpath, outfname_base + ".pu")
+            dest_pu_png = join(destpath, outfname_base + ".png")
 
             print(dest_dot)
             mm = metamodel_from_file(inname, debug=debug)
@@ -48,7 +48,7 @@ def main(path=None, debug=False, reportfilename=None):
             md.write('\n')
             with open(inname, "rt") as gr:
                 for l in gr:
-                    md.write("\t\t"+l)
+                    md.write("\t\t" + l)
             md.write('\n')
             rel_dest_dot_png = os.path.relpath(
                 dest_dot_png, dirname(reportfilename))

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,9 +76,10 @@ textx_languages =
 universal=1
 
 [flake8]
-exclude = .git/*,.eggs/*,.tox/*,
+ignore = E741,W503
+exclude = .git/*,.eggs/*,
           textx/six.py,
           textx/lang.py,
           tests/perf/*,
-          build/*,venv/*,
+          build/*,site/*,venv*,
           .ropeproject/*

--- a/tests/functional/examples/test_hierarchical_data_structures_referencing_attributes.py
+++ b/tests/functional/examples/test_hierarchical_data_structures_referencing_attributes.py
@@ -2,6 +2,27 @@ from __future__ import unicode_literals
 from textx import metamodel_from_str
 from pytest import raises
 import textx.exceptions
+import attr
+
+
+@attr.s(frozen=True)
+class Instance(object):
+    parent = attr.ib()
+    name = attr.ib()
+    type = attr.ib()
+
+
+@attr.s(frozen=True)
+class Reference(object):
+    parent = attr.ib()
+    instance = attr.ib()
+    refs = attr.ib()
+
+
+@attr.s(frozen=True)
+class RefItem(object):
+    parent = attr.ib()
+    valref = attr.ib()
 
 
 def test_referencing_attributes():
@@ -13,6 +34,8 @@ def test_referencing_attributes():
     With this, the list "refs" to "RefItem"s in the "Reference" object is
     build completely during initial parsing. The references inside the
     "RefItem"s, can the be resolved on after the other...
+
+    We also show how to handle custom classes here.
     """
     grammar = '''
     Model:
@@ -53,73 +76,80 @@ def test_referencing_attributes():
     reference a.x
     '''
 
-    def ref_scope(refItem, attr, attr_ref):
-        from textx.scoping.tools import get_named_obj_in_list
-        from textx.scoping import Postponed
-        from textx import textx_isinstance
-        reference = refItem.parent
-        if reference is None:
-            return Postponed()
-        index = reference.refs.index(refItem)
-        assert (index >= 0)
+    for classes in [[], [Instance, Reference, RefItem]]:
 
-        base = reference.instance if index == 0 \
-            else reference.refs[index - 1].valref
-        if base is None or base.type is None:
-            return Postponed()
-        x = get_named_obj_in_list(base.type.vals, attr_ref.obj_name)
+        def ref_scope(refItem, myattr, attr_ref):
+            from textx.scoping.tools import get_named_obj_in_list
+            from textx.scoping import Postponed
+            from textx import textx_isinstance
 
-        if index == len(reference.refs)-1:
-            if not textx_isinstance(x, attr.cls):
-                print(x)
-                return None
-        return x
+            reference = refItem.parent
 
-    mm = metamodel_from_str(grammar)
-    mm.register_scope_providers({
-        "RefItem.valref": ref_scope
-    })
-    m = mm.model_from_str(model_text)
+            if reference is None:
+                return Postponed()
 
-    assert m.references[0].refs[-1].valref.name == 'x'
-    assert m.references[0].refs[-1].valref == m.structs[0].vals[0]
+            index = list(map(
+                lambda x: id(x), reference.refs)).index(id(refItem))
 
-    assert m.references[0].refs[-2].valref.name == 'a'
-    assert m.references[0].refs[-2].valref == m.structs[1].vals[0]
+            assert index >= 0
 
-    assert m.references[0].refs[-3].valref.name == 'b'
-    assert m.references[0].refs[-3].valref == m.structs[2].vals[0]
+            base = reference.instance if index == 0 \
+                else reference.refs[index - 1].valref
+            if base is None or base.type is None:
+                return Postponed()
+            x = get_named_obj_in_list(base.type.vals, attr_ref.obj_name)
+            if index == len(reference.refs) - 1:
+                if not textx_isinstance(x, myattr.cls):
+                    print(x)
+                    return None
 
-    assert m.references[1].refs[-1].valref == m.structs[0].vals[0]
+            return x
 
-    assert m.references[2].refs[0].valref.name == 'x'
-    assert m.references[2].refs[0].valref == m.structs[0].vals[0]
+        mm = metamodel_from_str(grammar, classes=classes)
+        mm.register_scope_providers({
+            "RefItem.valref": ref_scope
+        })
+        m = mm.model_from_str(model_text)
 
-    # negative tests
-    # error: "not_there" not pasrt of A
-    with raises(textx.exceptions.TextXSemanticError,
-                match=r'.*Unknown object.*not_there.*'):
-        mm.model_from_str('''
-        struct A { val x }
-        struct B { val a: A}
-        struct C {
-            val b: B
-            val a: A
-        }
-        instance c: C
-        reference c.b.a.not_there
-        ''')
+        assert m.references[0].refs[-1].valref.name == 'x'
+        assert m.references[0].refs[-1].valref == m.structs[0].vals[0]
 
-    # error: B.a is not of type A
-    with raises(textx.exceptions.TextXSemanticError,
-                match=r'.*Unresolvable cross references.*x.*'):
-        mm.model_from_str('''
-        struct A { val x }
-        struct B { val a }
-        struct C {
-            val b: B
-            val a: A
-        }
-        instance c: C
-        reference c.b.a.x
-        ''')
+        assert m.references[0].refs[-2].valref.name == 'a'
+        assert m.references[0].refs[-2].valref == m.structs[1].vals[0]
+
+        assert m.references[0].refs[-3].valref.name == 'b'
+        assert m.references[0].refs[-3].valref == m.structs[2].vals[0]
+
+        assert m.references[1].refs[-1].valref == m.structs[0].vals[0]
+
+        assert m.references[2].refs[0].valref.name == 'x'
+        assert m.references[2].refs[0].valref == m.structs[0].vals[0]
+
+        # negative tests
+        # error: "not_there" not pasrt of A
+        with raises(textx.exceptions.TextXSemanticError,
+                    match=r'.*Unknown object.*not_there.*'):
+            mm.model_from_str('''
+            struct A { val x }
+            struct B { val a: A}
+            struct C {
+                val b: B
+                val a: A
+            }
+            instance c: C
+            reference c.b.a.not_there
+            ''')
+
+        # error: B.a is not of type A
+        with raises(textx.exceptions.TextXSemanticError,
+                    match=r'.*Unresolvable cross references.*x.*'):
+            mm.model_from_str('''
+            struct A { val x }
+            struct B { val a }
+            struct C {
+                val b: B
+                val a: A
+            }
+            instance c: C
+            reference c.b.a.x
+            ''')

--- a/tests/functional/regressions/test_issue128.py
+++ b/tests/functional/regressions/test_issue128.py
@@ -47,7 +47,7 @@ def test_abstract_alternative_string_match():
 
     def assertIs(x, rule):
         assert _is(x, rule), 'Unexpected object "{}" to rule "{}"'\
-                    .format(x, type(x), rule)
+            .format(x, rule)
 
     def evaluate(x):
 
@@ -102,7 +102,7 @@ def test_abstract_alternative_string_match():
 
         else:
             assert False, 'Unexpected object "{}" of type "{}"'\
-                    .format(x, type(x))
+                .format(x, type(x))
 
     result = evaluate(model)
 

--- a/tests/functional/regressions/test_issue140.py
+++ b/tests/functional/regressions/test_issue140.py
@@ -16,7 +16,7 @@ class C1(object):
 def test_multi_metamodel_obj_proc():
     global_repo = scoping.GlobalModelRepository()
     repo = scoping_providers.PlainNameGlobalRepo()
-    repo.register_models(os.path.dirname(__file__)+"/issue140/*.a")
+    repo.register_models(os.path.dirname(__file__) + "/issue140/*.a")
 
     mm_A = metamodel_from_file(os.path.join(
         os.path.dirname(__file__),

--- a/tests/functional/regressions/test_issue78.py
+++ b/tests/functional/regressions/test_issue78.py
@@ -40,8 +40,8 @@ def test_issue78_obj_processors_order_of_eval():
     ''')
     test_list = []
     mm.register_obj_processors({
-        'Base': lambda o: test_list.append('Base_'+o.name),
-        'Special1': lambda o: test_list.append('Special_'+o.name),
+        'Base': lambda o: test_list.append('Base_' + o.name),
+        'Special1': lambda o: test_list.append('Special_' + o.name),
     })
     mm.model_from_str('''
     1 S1
@@ -63,8 +63,8 @@ def test_issue78_obj_processors_replacement1_base():
     ''')
     test_list = []
     mm.register_obj_processors({
-        'Base': lambda o: 'Base_'+o.name,
-        'Special1': lambda o: test_list.append('Special_'+o.name),
+        'Base': lambda o: 'Base_' + o.name,
+        'Special1': lambda o: test_list.append('Special_' + o.name),
     })
     m = mm.model_from_str('''
     1 S1
@@ -87,8 +87,8 @@ def test_issue78_obj_processors_replacement2_specialized():
     ''')
     test_list = []
     mm.register_obj_processors({
-        'Base': lambda o: test_list.append('Base_'+o.name),
-        'Special1': lambda o: 'Special_'+o.name,
+        'Base': lambda o: test_list.append('Base_' + o.name),
+        'Special1': lambda o: 'Special_' + o.name,
     })
     m = mm.model_from_str('''
     1 S1
@@ -112,8 +112,8 @@ def test_issue78_obj_processors_replacement_domination_of_specialized():
         Base: Special1|Special2;
     ''')
     mm.register_obj_processors({
-        'Base': lambda o: 'Base_'+o.name,
-        'Special1': lambda o: 'Special_'+o.name,
+        'Base': lambda o: 'Base_' + o.name,
+        'Special1': lambda o: 'Special_' + o.name,
     })
     m = mm.model_from_str('''
     1 S1

--- a/tests/functional/regressions/test_issue_80_object_processors.py
+++ b/tests/functional/regressions/test_issue_80_object_processors.py
@@ -67,7 +67,7 @@ def parse_str(grammar, lola_str):
         "Formula": default_processor,
         "FormulaExpression": default_processor,
         "bar": default_processor,
-        }
+    }
 
     meta_model = metamodel_from_str(grammar, ignore_case=True,
                                     auto_init_attributes=False)

--- a/tests/functional/test_processors.py
+++ b/tests/functional/test_processors.py
@@ -78,7 +78,7 @@ def test_object_processors():
     obj_processors = {
         'First': first_obj_processor,
         'Second': second_obj_processor,
-        }
+    }
 
     metamodel = metamodel_from_str(grammar)
     metamodel.register_obj_processors(obj_processors)
@@ -113,7 +113,7 @@ def test_object_processors_user_classes():
     obj_processors = {
         'First': first_obj_processor,
         'Second': second_obj_processor,
-        }
+    }
 
     class First(object):
         def __init__(self, seconds, a, b, c):
@@ -154,7 +154,7 @@ def test_object_processor_replace_object():
     obj_processors = {
         'Second': second_obj_processor,
         'STRING': string_obj_processor,
-        }
+    }
 
     metamodel = metamodel_from_str(grammar)
     metamodel.register_obj_processors(obj_processors)

--- a/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
+++ b/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
@@ -37,7 +37,7 @@ def test_importURI_variations_import_string_hook():
     my_meta_model = metamodel_from_str(grammar)
 
     def conv(i):
-        return i.replace(".", "/")+".model"
+        return i.replace(".", "/") + ".model"
 
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.FQNImportURI(importURI_converter=conv)})
@@ -72,7 +72,7 @@ def test_importURI_variations_import_as_ok1():
     my_meta_model = metamodel_from_str(grammar)
 
     def conv(i):
-        return i.replace(".", "/")+".model"
+        return i.replace(".", "/") + ".model"
 
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.FQNImportURI(importURI_converter=conv,
@@ -108,7 +108,7 @@ def test_importURI_variations_import_as_ok2():
     my_meta_model = metamodel_from_str(grammar)
 
     def conv(i):
-        return i.replace(".", "/")+".model"
+        return i.replace(".", "/") + ".model"
 
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.FQNImportURI(importURI_converter=conv,
@@ -144,7 +144,7 @@ def test_importURI_variations_import_as_multi_import():
     my_meta_model = metamodel_from_str(grammar)
 
     def conv(i):
-        return i.replace(".", "/")+".model"
+        return i.replace(".", "/") + ".model"
 
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.FQNImportURI(importURI_converter=conv,
@@ -180,7 +180,7 @@ def test_importURI_variations_import_as_error():
     my_meta_model = metamodel_from_str(grammar)
 
     def conv(i):
-        return i.replace(".", "/")+".model"
+        return i.replace(".", "/") + ".model"
 
     my_meta_model.register_scope_providers(
         {"*.*": scoping_providers.FQNImportURI(importURI_converter=conv,

--- a/tests/functional/test_scoping/test_metamodel_provider3_custom_classes.py
+++ b/tests/functional/test_scoping/test_metamodel_provider3_custom_classes.py
@@ -1,0 +1,475 @@
+from __future__ import unicode_literals
+
+from os.path import dirname, abspath, join
+
+import textx.scoping.providers as scoping_providers
+from textx import get_children_of_type
+from textx import (metamodel_from_file, register_language,
+                   clear_language_registrations)
+import attr
+
+
+@attr.s(frozen=True)
+class Cls(object):
+    parent = attr.ib()
+    name = attr.ib()
+    extends = attr.ib()
+    methods = attr.ib()
+
+
+@attr.s(frozen=True)
+class Obj(object):
+    parent = attr.ib()
+    name = attr.ib()
+    ref = attr.ib()
+
+
+def test_metamodel_provider_advanced_test3_global():
+    """
+    Advanced test for ExtRelativeName and PlainNameGlobalRepo.
+
+    Here we have a global model repository shared between
+    different meta models.
+
+    The meta models interact (refer to each other, different directions).
+    """
+    #################################
+    # META MODEL DEF
+    #################################
+    this_folder = dirname(abspath(__file__))
+
+    def get_meta_model(global_repo, grammar_file_name):
+        mm = metamodel_from_file(join(this_folder, grammar_file_name),
+                                 debug=False, classes=[Cls, Obj])
+        mm.register_scope_providers({
+            "*.*": global_repo,
+        })
+        return mm
+
+    global_repo_provider = scoping_providers.PlainNameGlobalRepo()
+    global_repo_provider.register_models(
+        join(this_folder, "metamodel_provider3", "circular", "*.a"))
+    global_repo_provider.register_models(
+        join(this_folder, "metamodel_provider3", "circular", "*.b"))
+    global_repo_provider.register_models(
+        join(this_folder, "metamodel_provider3", "circular", "*.c"))
+
+    a_mm = get_meta_model(
+        global_repo_provider, join(this_folder,
+                                   "metamodel_provider3", "A.tx"))
+    b_mm = get_meta_model(
+        global_repo_provider, join(this_folder,
+                                   "metamodel_provider3", "B.tx"))
+    c_mm = get_meta_model(
+        global_repo_provider, join(this_folder,
+                                   "metamodel_provider3", "C.tx"))
+
+    clear_language_registrations()
+    register_language(
+        'a-dsl',
+        pattern='*.a',
+        description='Test Lang A',
+        metamodel=a_mm)
+    register_language(
+        'b-dsl',
+        pattern='*.b',
+        description='Test Lang B',
+        metamodel=b_mm)
+    register_language(
+        'c-dsl',
+        pattern='*.c',
+        description='Test Lang C',
+        metamodel=c_mm)
+
+    #################################
+    # MODEL PARSING
+    #################################
+
+    model_repo = global_repo_provider.load_models_in_model_repo().all_models
+
+    #################################
+    # TEST MODEL
+    #################################
+
+    def get_all(model_repo, what):
+        lst = []
+        for m in model_repo.filename_to_model.values():
+            lst = lst + get_children_of_type(what, m)
+        return lst
+
+    lst = get_all(model_repo, "Obj")
+    # print(lst)
+    assert len(lst) == 3
+
+    # check some references to be resolved (!=None)
+    for a in lst:
+        assert a.ref
+
+    # check meta classes
+    assert a_mm["Cls"]._tx_fqn == b_mm["Cls"]._tx_fqn
+
+    # more checks
+    from textx import textx_isinstance
+    for a in lst:
+        assert textx_isinstance(a, a_mm["Obj"])
+        assert textx_isinstance(a, b_mm["Obj"])
+        assert textx_isinstance(a, c_mm["Obj"])
+
+    #################################
+    # END
+    #################################
+    clear_language_registrations()
+
+
+def test_metamodel_provider_advanced_test3_import():
+    """
+    Advanced test for ExtRelativeName and PlainNameImportURI.
+
+    Here we have a global model repository shared between
+    different meta models.
+
+    The meta models interact (refer to each other, different directions).
+    """
+    #################################
+    # META MODEL DEF
+    #################################
+    this_folder = dirname(abspath(__file__))
+
+    def get_meta_model(provider, grammar_file_name):
+        mm = metamodel_from_file(join(this_folder, grammar_file_name),
+                                 debug=False, classes=[Cls, Obj])
+        mm.register_scope_providers({
+            "*.*": provider,
+        })
+        return mm
+
+    import_lookup_provider = scoping_providers.PlainNameImportURI()
+
+    a_mm = get_meta_model(
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "A.tx"))
+    b_mm = get_meta_model(
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "B.tx"))
+    c_mm = get_meta_model(
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "C.tx"))
+
+    clear_language_registrations()
+    register_language(
+        'a-dsl',
+        pattern='*.a',
+        description='Test Lang A',
+        metamodel=a_mm)
+    register_language(
+        'b-dsl',
+        pattern='*.b',
+        description='Test Lang B',
+        metamodel=b_mm)
+    register_language(
+        'c-dsl',
+        pattern='*.c',
+        description='Test Lang C',
+        metamodel=c_mm)
+
+    #################################
+    # MODEL PARSING
+    #################################
+
+    m = a_mm.model_from_file(
+        join(this_folder, "metamodel_provider3", "circular", "model_a.a"))
+    model_repo = m._tx_model_repository.all_models
+
+    #################################
+    # TEST MODEL
+    #################################
+
+    def get_all(model_repo, what):
+        lst = []
+        for m in model_repo.filename_to_model.values():
+            lst = lst + get_children_of_type(what, m)
+        return lst
+
+    lst = get_all(model_repo, "Obj")
+    # print(lst)
+    assert len(lst) == 3
+
+    # check all references to be resolved (!=None)
+    for a in lst:
+        assert a.ref
+
+    #################################
+    # END
+    #################################
+    clear_language_registrations()
+
+
+def test_metamodel_provider_advanced_test3_inheritance():
+    """
+    Advanced test for ExtRelativeName and FQNImportURI.
+
+    Here we have a global model repository shared between
+    different meta models.
+
+    The meta models interact (refer to each other, different directions,
+    A inherits from B, the B from A, etc.).
+
+    It is checked that all relevant references are resolved.
+    """
+    #################################
+    # META MODEL DEF
+    #################################
+    this_folder = dirname(abspath(__file__))
+
+    def get_meta_model(provider, grammar_file_name):
+        mm = metamodel_from_file(join(this_folder, grammar_file_name),
+                                 debug=False, classes=[Cls, Obj])
+        mm.register_scope_providers({
+            "*.*": provider,
+            "Call.method": scoping_providers.ExtRelativeName("obj.ref",
+                                                             "methods",
+                                                             "extends")
+        })
+        return mm
+
+    import_lookup_provider = scoping_providers.FQNImportURI()
+
+    a_mm = get_meta_model(
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "A.tx"))
+    b_mm = get_meta_model(
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "B.tx"))
+    c_mm = get_meta_model(
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "C.tx"))
+
+    clear_language_registrations()
+    register_language(
+        'a-dsl',
+        pattern='*.a',
+        description='Test Lang A',
+        metamodel=a_mm)
+    register_language(
+        'b-dsl',
+        pattern='*.b',
+        description='Test Lang B',
+        metamodel=b_mm)
+    register_language(
+        'c-dsl',
+        pattern='*.c',
+        description='Test Lang C',
+        metamodel=c_mm)
+
+    #################################
+    # MODEL PARSING
+    #################################
+
+    m = a_mm.model_from_file(
+        join(this_folder, "metamodel_provider3",
+             "inheritance", "model_a.a"))
+    model_repo = m._tx_model_repository.all_models
+
+    #################################
+    # TEST MODEL (dependencies from one file to the other and back again)
+    # - checks all references are resolved
+    #################################
+
+    def get_all(model_repo, what):
+        lst = []
+        for m in model_repo.filename_to_model.values():
+            lst = lst + get_children_of_type(what, m)
+        return lst
+
+    lst = get_all(model_repo, "Call")
+    assert len(lst) > 0
+
+    # check all references to be resolved (!=None)
+    for a in lst:
+        assert a.method
+
+    #################################
+    # END
+    #################################
+    clear_language_registrations()
+
+
+def test_metamodel_provider_advanced_test3_inheritance2():
+    """
+    More complicated model (see test above). It is also checked that
+    the parsers are correctly cloned.
+    """
+    #################################
+    # META MODEL DEF
+    #################################
+    this_folder = dirname(abspath(__file__))
+
+    def get_meta_model(provider, grammar_file_name):
+        mm = metamodel_from_file(join(this_folder, grammar_file_name),
+                                 debug=False, classes=[Cls, Obj])
+        mm.register_scope_providers({
+            "*.*": provider,
+            "Call.method": scoping_providers.ExtRelativeName("obj.ref",
+                                                             "methods",
+                                                             "extends")
+        })
+        return mm
+
+    import_lookup_provider = scoping_providers.FQNImportURI()
+
+    a_mm = get_meta_model(
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "A.tx"))
+    b_mm = get_meta_model(
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "B.tx"))
+    c_mm = get_meta_model(
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "C.tx"))
+
+    clear_language_registrations()
+    register_language(
+        'a-dsl',
+        pattern='*.a',
+        description='Test Lang A',
+        metamodel=a_mm)
+    register_language(
+        'b-dsl',
+        pattern='*.b',
+        description='Test Lang B',
+        metamodel=b_mm)
+    register_language(
+        'c-dsl',
+        pattern='*.c',
+        description='Test Lang C',
+        metamodel=c_mm)
+
+    #################################
+    # MODEL PARSING
+    #################################
+
+    m = a_mm.model_from_file(
+        join(this_folder, "metamodel_provider3",
+             "inheritance2", "model_a.a"))
+    model_repo = m._tx_model_repository.all_models
+
+    #################################
+    # TEST MODEL (inheritance)
+    # - check all references are resolved
+    # - check all models have an own parser
+    #################################
+
+    def get_all(model_repo, what):
+        lst = []
+        for m in model_repo.filename_to_model.values():
+            lst = lst + get_children_of_type(what, m)
+        return lst
+
+    lst = get_all(model_repo, "Call")
+    assert len(lst) > 0
+
+    # check all references to be resolved (!=None)
+    for a in lst:
+        assert a.method
+
+    # check that all models have different parsers
+    parsers = list(
+        map(lambda x: x._tx_parser, model_repo.filename_to_model.values()))
+    assert 4 == len(parsers)  # 4 files -> 4 parsers
+    assert 4 == len(set(parsers))  # 4 different parsers
+
+    #################################
+    # END
+    #################################
+    clear_language_registrations()
+
+
+def test_metamodel_provider_advanced_test3_diamond():
+    """
+    More complicated model (see test above): here we have a
+    diamond shared dependency. It is also checked that
+    the parsers are correctly cloned.
+    """
+    #################################
+    # META MODEL DEF
+    #################################
+    this_folder = dirname(abspath(__file__))
+
+    def get_meta_model(provider, grammar_file_name):
+        mm = metamodel_from_file(join(this_folder, grammar_file_name),
+                                 debug=False, classes=[Cls, Obj])
+        mm.register_scope_providers({
+            "*.*": provider,
+            "Call.method": scoping_providers.ExtRelativeName("obj.ref",
+                                                             "methods",
+                                                             "extends")
+        })
+        return mm
+
+    import_lookup_provider = scoping_providers.FQNImportURI()
+
+    a_mm = get_meta_model(
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "A.tx"))
+    b_mm = get_meta_model(
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "B.tx"))
+    c_mm = get_meta_model(
+        import_lookup_provider, join(this_folder,
+                                     "metamodel_provider3", "C.tx"))
+
+    clear_language_registrations()
+    register_language(
+        'a-dsl',
+        pattern='*.a',
+        description='Test Lang A',
+        metamodel=a_mm)
+    register_language(
+        'b-dsl',
+        pattern='*.b',
+        description='Test Lang B',
+        metamodel=b_mm)
+    register_language(
+        'c-dsl',
+        pattern='*.c',
+        description='Test Lang C',
+        metamodel=c_mm)
+
+    #################################
+    # MODEL PARSING
+    #################################
+
+    m = a_mm.model_from_file(
+        join(this_folder, "metamodel_provider3",
+             "diamond", "A_includes_B_C.a"))
+    model_repo = m._tx_model_repository.all_models
+
+    #################################
+    # TEST MODEL (inheritance, diamond include structure)
+    # - check all references are resolved
+    # - check all models have an own parser
+    #################################
+
+    def get_all(model_repo, what):
+        lst = []
+        for m in model_repo.filename_to_model.values():
+            lst = lst + get_children_of_type(what, m)
+        return lst
+
+    lst = get_all(model_repo, "Call")
+    assert len(lst) > 0
+
+    # check all references to be resolved (!=None)
+    for a in lst:
+        assert a.method
+
+    # check that all models have different parsers
+    parsers = list(
+        map(lambda x: x._tx_parser, model_repo.filename_to_model.values()))
+    assert 4 == len(parsers)  # 4 files -> 4 parsers
+    assert 4 == len(set(parsers))  # 4 different parsers
+
+    #################################
+    # END
+    #################################
+    clear_language_registrations()

--- a/tests/functional/test_scoping/test_scoping_tools.py
+++ b/tests/functional/test_scoping/test_scoping_tools.py
@@ -7,8 +7,190 @@ from textx.scoping.tools import resolve_model_path,\
     get_list_of_concatenated_objects
 from textx.scoping.tools import get_unique_named_object
 from textx import textx_isinstance
-from textx import get_children_of_type
+from textx import get_children_of_type, get_model
 from pytest import raises
+import attr
+
+
+def test_textx_tools_with_frozen_classes1():
+
+    @attr.s(frozen=True)
+    class Model(object):
+        # _tx_filename = attr.ib()
+        # _tx_parser = attr.ib()
+        use = attr.ib()
+        data = attr.ib()
+
+    @attr.s(frozen=True)
+    class Content(object):
+        parent = attr.ib()
+        elementsA = attr.ib()
+        elementsB = attr.ib()
+        ref = attr.ib()
+
+    @attr.s(frozen=True)
+    class Element(object):
+        parent = attr.ib()
+        name = attr.ib()
+
+    grammar = r'''
+    Model:
+        'use' use=Use
+        data=Content;
+    Content:
+        'A:' elementsA+=Element
+        'B:' elementsB+=Element
+        'ref' ref=[Element];
+    Element: '*' name=ID;
+    Use: 'A'|'B';
+    '''
+    text_ok1 = r'''
+        use A
+        A: *a *b *c
+        B: *d *e *f
+        ref b
+    '''
+    text_ok2 = r'''
+        use B
+        A: *a *b *c
+        B: *d *e *f
+        ref d
+    '''
+    text_not_ok = r'''
+        use B
+        A: *a *b *c
+        B: *d *e *f
+        ref b
+    '''
+    for classes in [[], [Model, Content, Element]]:
+        print("Test Loop, classes==", classes)
+
+        ref_scope_was_used = [False]
+
+        def ref_scope(refItem, myattr, attr_ref):
+            # python3: nonlocal ref_scope_was_used
+            ref_scope_was_used[0] = True
+            if get_model(refItem).use == 'A':
+                return resolve_model_path(
+                    refItem, "parent(Model).data.elementsA.{}".format(
+                        attr_ref.obj_name), True)
+            else:
+                return resolve_model_path(
+                    refItem, "parent(Model).data.elementsB.{}".format(
+                        attr_ref.obj_name), True)
+
+        mm = metamodel_from_str(grammar, classes=classes)
+        mm.register_scope_providers({
+            "Content.ref": ref_scope
+        })
+        ref_scope_was_used[0] = False
+        m = mm.model_from_str(text_ok1)
+        assert ref_scope_was_used[0]
+        if len(classes) == 0:
+            assert hasattr(m, '_tx_filename')
+            assert hasattr(m, '_tx_metamodel')
+        else:
+            # TODO: should we take care of not having special fields
+            # in that case?
+            # (also applied for importURI fields (which get also some
+            # special fields).
+            assert not hasattr(m, '_tx_filename')
+            assert not hasattr(m, '_tx_metamodel')
+
+        ref_scope_was_used[0] = False
+        mm.model_from_str(text_ok2)
+        assert ref_scope_was_used[0]
+
+        ref_scope_was_used[0] = False
+        with raises(Exception, match=r'.*Unknown object "b".*'):
+            mm.model_from_str(text_not_ok)
+        assert ref_scope_was_used[0]
+
+
+def test_textx_tools_with_frozen_classes2():
+
+    class Model(object):
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    @attr.s(frozen=True)
+    class Content(object):
+        parent = attr.ib()
+        elementsA = attr.ib()
+        elementsB = attr.ib()
+        ref = attr.ib()
+
+    @attr.s(frozen=True)
+    class Element(object):
+        parent = attr.ib()
+        name = attr.ib()
+
+    grammar = r'''
+    Model:
+        'use' use=Use
+        data=Content;
+    Content:
+        'A:' elementsA+=Element
+        'B:' elementsB+=Element
+        'ref' ref=[Element];
+    Element: '*' name=ID;
+    Use: 'A'|'B';
+    '''
+    text_ok1 = r'''
+        use A
+        A: *a *b *c
+        B: *d *e *f
+        ref b
+    '''
+    text_ok2 = r'''
+        use B
+        A: *a *b *c
+        B: *d *e *f
+        ref d
+    '''
+    text_not_ok = r'''
+        use B
+        A: *a *b *c
+        B: *d *e *f
+        ref b
+    '''
+    for classes in [[], [Model, Content, Element]]:
+        print("Test Loop, classes==", classes)
+
+        ref_scope_was_used = [False]
+
+        def ref_scope(refItem, myattr, attr_ref):
+            # python3: nonlocal ref_scope_was_used
+            ref_scope_was_used[0] = True
+            if get_model(refItem).use == 'A':
+                return resolve_model_path(
+                    refItem, "parent(Model).data.elementsA.{}".format(
+                        attr_ref.obj_name), True)
+            else:
+                return resolve_model_path(
+                    refItem, "parent(Model).data.elementsB.{}".format(
+                        attr_ref.obj_name), True)
+
+        mm = metamodel_from_str(grammar, classes=classes)
+        mm.register_scope_providers({
+            "Content.ref": ref_scope
+        })
+        ref_scope_was_used[0] = False
+        m = mm.model_from_str(text_ok1)
+        assert ref_scope_was_used[0]
+
+        assert hasattr(m, '_tx_filename')
+        assert hasattr(m, '_tx_metamodel')
+
+        ref_scope_was_used[0] = False
+        mm.model_from_str(text_ok2)
+        assert ref_scope_was_used[0]
+
+        ref_scope_was_used[0] = False
+        with raises(Exception, match=r'.*Unknown object "b".*'):
+            mm.model_from_str(text_not_ok)
+        assert ref_scope_was_used[0]
 
 
 def test_textx_isinstace():

--- a/tests/functional/test_scoping/test_scoping_tools.py
+++ b/tests/functional/test_scoping/test_scoping_tools.py
@@ -87,15 +87,13 @@ def test_textx_tools_with_frozen_classes1():
         m = mm.model_from_str(text_ok1)
         assert ref_scope_was_used[0]
         if len(classes) == 0:
-            assert hasattr(m, '_tx_filename')
-            assert hasattr(m, '_tx_metamodel')
+            # Assert that model object has its own filename and metamodel
+            assert '_tx_filename' in m.__dict__
+            assert '_tx_metamodel' in m.__dict__
         else:
-            # TODO: should we take care of not having special fields
-            # in that case?
-            # (also applied for importURI fields (which get also some
-            # special fields).
-            assert not hasattr(m, '_tx_filename')
-            assert not hasattr(m, '_tx_metamodel')
+            # Assert that special attributes are accessible only through class
+            assert '_tx_filename' not in m.__dict__
+            assert '_tx_metamodel' not in m.__dict__
 
         ref_scope_was_used[0] = False
         mm.model_from_str(text_ok2)

--- a/tests/functional/test_textx_tools_support.py
+++ b/tests/functional/test_textx_tools_support.py
@@ -58,4 +58,4 @@ def test_textx_tools_support():
     rules_len = len(rules_keys)
     assert rules_len > 0
     assert rules_keys[0][0] > \
-        rules_keys[rules_len-1][0]
+        rules_keys[rules_len - 1][0]

--- a/tests/functional/test_user_class_attrs_frozen.py
+++ b/tests/functional/test_user_class_attrs_frozen.py
@@ -2,33 +2,22 @@ from __future__ import unicode_literals
 import pytest  # noqa
 from textx import metamodel_from_str
 
-grammar = """
-Document:
-    a=A
-    b=B
-;
-A:
-    'A' name=ID
-;
-B:
-    'B' 'a' '=' a=[A]
-;
-"""
-
 
 @pytest.mark.parametrize('frozen', [False, True])
 def test_user_class_attrs(frozen):
     attr = pytest.importorskip('attr')
+    grammar = """
+    Document:
+        a=A
+        b=B
+    ;
+    A:
+        'A' name=ID
+    ;
+    B:
+        'B' 'a' '=' a=[A]
+    ;
     """
-    User supplied meta class.
-    """
-    @attr.s(frozen=frozen)
-    class Point(object):
-        "User class."
-        parent = attr.ib()
-        name = attr.ib()
-        x = attr.ib()
-        y = attr.ib()
 
     modelstr = """
     A something
@@ -49,3 +38,38 @@ def test_user_class_attrs(frozen):
                             auto_init_attributes=False)
     model = mm.model_from_str(modelstr)
     assert model.b.a == model.a
+
+
+def test_inheritance_attrs():
+    attr = pytest.importorskip('attr')
+
+    grammar = """
+    Document:
+        super=Super
+        sub=Sub
+    ;
+    Super:
+        'Super' a=INT
+    ;
+    Sub:
+        'Sub' a=INT b=ID
+    ;
+    """
+
+    modelstr = """
+    Super 1
+    Sub 2 something
+    """
+
+    @attr.s()
+    class Super(object):
+        parent = attr.ib()
+        a = attr.ib()
+
+    @attr.s()
+    class Sub(Super):
+        b = attr.ib()
+
+    mm = metamodel_from_str(grammar, classes=[Super, Sub])
+    model = mm.model_from_str(modelstr)
+    assert model.sub.b == 'something'

--- a/textx/export.py
+++ b/textx/export.py
@@ -42,8 +42,8 @@ def dot_match_str(cls, other_match_rules=None):
         if s.root:
             # breakpoint()
             if s in visited or s.rule_name in ALL_TYPE_NAMES or \
-                    (hasattr(s, '_tx_class') and
-                     (s._tx_class._tx_type is not RULE_MATCH
+                    (hasattr(s, '_tx_class')
+                     and (s._tx_class._tx_type is not RULE_MATCH
                      or (s._tx_class in other_match_rules
                          and s._tx_class is not cls))):
                 # print("==> NAME " + s.rule_name)
@@ -72,8 +72,8 @@ def dot_match_str(cls, other_match_rules=None):
 
     mstr = ""
     # print("---------- "+str(cls))
-    if not (cls._tx_type is RULE_ABSTRACT and
-            cls.__name__ != cls._tx_peg_rule.rule_name):
+    if not (cls._tx_type is RULE_ABSTRACT
+            and cls.__name__ != cls._tx_peg_rule.rule_name):
         e = cls._tx_peg_rule
         visited = set()
         if other_match_rules is None:
@@ -153,8 +153,8 @@ class DotRenderer(object):
                         attr.name, attr_type
                         if required else r'optional\<{}\>'.format(attr_type))
         return '{}[ label="{{{}|{}}}"]\n\n'.format(
-                id(cls), "*{}".format(name)
-                if cls._tx_type is RULE_ABSTRACT else name, attrs)
+            id(cls), "*{}".format(name)
+            if cls._tx_type is RULE_ABSTRACT else name, attrs)
 
     def render_attr_link(self, cls, attr):
         arrowtail = "arrowtail=diamond, dir=both, " \
@@ -221,10 +221,9 @@ set namespaceSeparator .
                         attrs += "  {} : optional<{}>\n".format(attr.name,
                                                                 attr_type)
         if len(stereotype) > 0:
-            stereotype = "<<"+stereotype+">>"
+            stereotype = "<<" + stereotype + ">>"
         return '\n\nclass {} {} {{\n{}}}\n'.format(
-                cls._tx_fqn, stereotype, attrs
-                )
+            cls._tx_fqn, stereotype, attrs)
 
     def render_attr_link(self, cls, attr):
         if attr.ref and attr.cls.__name__ != 'OBJECT':

--- a/textx/metamodel.py
+++ b/textx/metamodel.py
@@ -89,30 +89,6 @@ class MetaAttr(object):
         self.position = position
 
 
-def _setattr(obj, name, value):
-    if hasattr(obj.__class__, '_tx_obj_attrs')\
-            and id(obj) in obj.__class__._tx_obj_attrs:
-        obj.__class__._tx_obj_attrs[id(obj)][name] = value
-    else:
-        setattr(obj, name, value)
-
-
-def _getattr(obj, name, *args):
-    if hasattr(obj.__class__, '_tx_obj_attrs')\
-            and id(obj) in obj.__class__._tx_obj_attrs:
-        return obj.__class__._tx_obj_attrs[id(obj)][name]
-    else:
-        return getattr(obj, name, *args)
-
-
-def _hasattr(obj, name):
-    if hasattr(obj.__class__, '_tx_obj_attrs')\
-            and id(obj) in obj.__class__._tx_obj_attrs:
-        return name in obj.__class__._tx_obj_attrs[id(obj)]
-    else:
-        return hasattr(obj, name)
-
-
 class TextXMetaModel(DebugPrinter):
     """
     Meta-model contains all information about language abstract syntax.
@@ -464,27 +440,27 @@ class TextXMetaModel(DebugPrinter):
         for attr in obj.__class__._tx_attrs.values():
             if attr.mult in [MULT_ZEROORMORE, MULT_ONEORMORE]:
                 # list
-                _setattr(obj, attr.name, [])
+                setattr(obj, attr.name, [])
             elif attr.cls.__name__ in BASE_TYPE_NAMES:
                 # Instantiate base python type
                 if self.auto_init_attributes:
-                    _setattr(obj, attr.name,
-                             python_type(attr.cls.__name__)())
+                    setattr(obj, attr.name,
+                            python_type(attr.cls.__name__)())
                 else:
                     # See https://github.com/textX/textX/issues/11
                     if attr.bool_assignment:
                         # Only ?= assignments shall have default
                         # value of False.
-                        _setattr(obj, attr.name, False)
+                        setattr(obj, attr.name, False)
                     else:
                         # Set base type attribute to None initially
                         # in order to be able to detect if an optional
                         # values are given in the model. Default values
                         # can be specified using object processors.
-                        _setattr(obj, attr.name, None)
+                        setattr(obj, attr.name, None)
             else:
                 # Reference to other obj
-                _setattr(obj, attr.name, None)
+                setattr(obj, attr.name, None)
 
     def _new_cls_attr(self, clazz, name, cls=None, mult=MULT_ONE, cont=True,
                       ref=False, bool_assignment=False, position=0):

--- a/textx/metamodel.py
+++ b/textx/metamodel.py
@@ -386,6 +386,7 @@ class TextXMetaModel(DebugPrinter):
         both for textX created classes as well as user classes.
         """
         cls._tx_metamodel = self
+        cls._tx_filename = self.file_name
 
         # Attribute information (MetaAttr instances) keyed by name.
         cls._tx_attrs = OrderedDict()
@@ -429,13 +430,11 @@ class TextXMetaModel(DebugPrinter):
         else:
             return ns + '.' + cls.__name__
 
-    def _init_obj_attrs(self, obj, user=False):
+    def _init_obj_attrs(self, obj):
         """
         Initialize obj attributes.
         Args:
             obj(object): A python object to set attributes to.
-            user(bool): If this object is a user object store attributes
-                outside the object.
         """
         for attr in obj.__class__._tx_attrs.values():
             if attr.mult in [MULT_ZEROORMORE, MULT_ONEORMORE]:

--- a/textx/model.py
+++ b/textx/model.py
@@ -305,7 +305,6 @@ def get_model_parser(top_rule, comments_model, **kwargs):
                     pass
             return super(type(obj), obj).__getattribute__(name)
 
-
         def _getattr(obj, name):
             try:
                 return obj._tx_obj_attrs[id(obj)][name]
@@ -340,7 +339,8 @@ def get_model_parser(top_rule, comments_model, **kwargs):
             """
             for user_class in self.metamodel.user_classes.values():
                 if not hasattr(user_class, '_tx_instrumented'):
-                    for a_name in ('getattr', 'setattr', 'delattr', 'getattribute'):
+                    for a_name in ('getattr', 'setattr', 'delattr',
+                                   'getattribute'):
                         real_name = '__{}__'.format(a_name)
                         cached_name = '_tx_real_{}'.format(a_name)
                         setattr(user_class, cached_name,
@@ -361,7 +361,8 @@ def get_model_parser(top_rule, comments_model, **kwargs):
                     user_class._tx_instrumented -= 1
                     if user_class._tx_instrumented == 0:
                         delattr(user_class, '_tx_instrumented')
-                        for a_name in ('getattr', 'setattr', 'delattr', 'getattribute'):
+                        for a_name in ('getattr', 'setattr', 'delattr',
+                                       'getattribute'):
                             cached_name = '_tx_real_{}'.format(a_name)
                             real_name = '__{}__'.format(a_name)
                             if hasattr(user_class, cached_name):
@@ -440,7 +441,7 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                         return process_node(
                             next(n for n in node
                                  if type(n) is not Terminal
-                                 and n.rule._tx_class is not RULE_MATCH))
+                                 and n.rule._tx_class is not RULE_MATCH))  # noqa
                     except StopIteration:
                         # All nodes are match rules, do concatenation
                         return ''.join(text(n) for n in node)

--- a/textx/model.py
+++ b/textx/model.py
@@ -296,41 +296,49 @@ def get_model_parser(top_rule, comments_model, **kwargs):
 
             return model
 
-        # Custom attr dunder methods used for user classes during loading
-        def _getattribute(obj, name):
-            if name == '__dict__':
+        def _replace_user_attr_methods_for_class(self, user_class):
+            # Custom attr dunder methods used for user classes during loading
+            def _getattribute(obj, name):
+                if name == '__dict__':
+                    try:
+                        return user_class._tx_obj_attrs[id(obj)]
+                    except KeyError:
+                        pass
+                else:
+                    try:
+                        return user_class._tx_obj_attrs[id(obj)][name]
+                    except KeyError:
+                        pass
+
+                return super(user_class, obj).__getattribute__(name)
+
+            def _setattr(obj, name, value):
                 try:
-                    return type(obj)._tx_obj_attrs[id(obj)]
+                    obj._tx_obj_attrs[id(obj)][name] = value
                 except KeyError:
-                    pass
-            return super(type(obj), obj).__getattribute__(name)
+                    try:
+                        return obj._tx_real_setattr(name, value)
+                    except (AttributeError, TypeError):
+                        return super(user_class, obj).__setattr__(name, value)
 
-        def _getattr(obj, name):
-            try:
-                return obj._tx_obj_attrs[id(obj)][name]
-            except KeyError:
+            def _delattr(obj, name):
                 try:
-                    return obj._tx_real_getattr(name)
-                except (AttributeError, TypeError):
-                    return super(type(obj), obj).__getattr__(name)
+                    obj._tx_obj_attrs[id(obj)].pop(name)
+                except KeyError:
+                    try:
+                        return obj._tx_real_delattr(name)
+                    except (AttributeError, TypeError):
+                        return super(user_class, obj).__delattr__(name)
 
-        def _setattr(obj, name, value):
-            try:
-                obj._tx_obj_attrs[id(obj)][name] = value
-            except KeyError:
-                try:
-                    return obj._tx_real_setattr(name, value)
-                except (AttributeError, TypeError):
-                    return super(type(obj), obj).__setattr__(name, value)
-
-        def _delattr(obj, name):
-            try:
-                obj._tx_obj_attrs[id(obj)].pop(name)
-            except KeyError:
-                try:
-                    return obj._tx_real_delattr(name)
-                except (AttributeError, TypeError):
-                    return super(type(obj), obj).__delattr__(name)
+            for a_name in ('setattr', 'delattr',
+                           'getattribute'):
+                real_name = '__{}__'.format(a_name)
+                cached_name = '_tx_real_{}'.format(a_name)
+                setattr(user_class, cached_name,
+                        getattr(user_class, real_name, None))
+                setattr(user_class, real_name,
+                        locals()['_{}'.format(a_name)])
+            user_class._tx_instrumented = 1
 
         def _replace_user_attr_methods(self):
             """
@@ -338,16 +346,8 @@ def get_model_parser(top_rule, comments_model, **kwargs):
             to support postponing of user obj initialization.
             """
             for user_class in self.metamodel.user_classes.values():
-                if not hasattr(user_class, '_tx_instrumented'):
-                    for a_name in ('getattr', 'setattr', 'delattr',
-                                   'getattribute'):
-                        real_name = '__{}__'.format(a_name)
-                        cached_name = '_tx_real_{}'.format(a_name)
-                        setattr(user_class, cached_name,
-                                getattr(user_class, real_name, None))
-                        setattr(user_class, real_name,
-                                getattr(self.__class__, '_{}'.format(a_name)))
-                    user_class._tx_instrumented = 1
+                if '_tx_instrumented' not in user_class.__dict__:
+                    self._replace_user_attr_methods_for_class(user_class)
                 else:
                     user_class._tx_instrumented += 1
 

--- a/textx/registration.py
+++ b/textx/registration.py
@@ -264,8 +264,8 @@ def metamodel_for_language(language_name, **kwargs):
             metamodels[language_name] = language.metamodel
         else:
             metamodel = language.metamodel(**kwargs)
-            if not (isinstance(metamodel, TextXMetaModel) or
-                    isinstance(metamodel, TextXMetaMetaModel)):
+            if not (isinstance(metamodel, TextXMetaModel)
+                    or isinstance(metamodel, TextXMetaMetaModel)):
                 raise TextXRegistrationError(
                     'Meta-model type for language "{}" is "{}".'
                     .format(language_name, type(metamodel).__name__))

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -8,7 +8,6 @@
 from os.path import dirname, abspath, join
 from textx.exceptions import TextXSemanticError
 import textx.scoping as scoping
-from textx.metamodel import _hasattr, _getattr
 from textx.scoping import Postponed
 
 """
@@ -91,7 +90,7 @@ class PlainName(object):
             from textx import textx_isinstance
             result_lst = get_children(
                 lambda x:
-                _hasattr(x, "name") and _getattr(x, "name") == obj_ref.obj_name
+                hasattr(x, "name") and x.name == obj_ref.obj_name
                 and textx_isinstance(x, obj_ref.cls), get_model(obj))
             if len(result_lst) == 1:
                 result = result_lst[0]
@@ -183,12 +182,11 @@ class FQN(object):
                     obj = getattr(parent, attr)
                     if isinstance(obj, (list, tuple)):
                         for innerobj in obj:
-                            if _hasattr(innerobj, "name") \
-                                    and _getattr(innerobj, "name") == name:
+                            if hasattr(innerobj, "name") \
+                                    and innerobj.name == name:
                                 return innerobj
                     else:
-                        if _hasattr(obj, "name") \
-                                and _getattr(obj, "name") == name:
+                        if hasattr(obj, "name") and obj.name == name:
                             return obj
                 return None
 
@@ -224,8 +222,8 @@ class FQN(object):
             ret = _find_obj_fqn(p, name, cls)
             if ret:
                 return ret
-            while _hasattr(p, "parent"):
-                p = _getattr(p, "parent")
+            while hasattr(p, "parent"):
+                p = p.parent
                 ret = _find_obj_fqn(p, name, cls)
                 if ret:
                     return ret
@@ -309,9 +307,8 @@ class ImportURI(scoping.ModelLoader):
             if self.importURI_to_scope_name is not None:
                 obj.name = self.importURI_to_scope_name(obj)
                 # print("setting name to {}".format(obj.name))
-            if _hasattr(obj, "name"):
-                if _getattr(obj, "name") is not None \
-                        and _getattr(obj, "name") != "":
+            if hasattr(obj, "name"):
+                if obj.name is not None and obj.name != "":
                     add_to_local_models = not self.importAs
 
             visited.append(obj)

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -411,10 +411,10 @@ class FQNImportURI(ImportURI):
             my_scope_redirection_logic = scope_redirection_logic
         ImportURI.__init__(self, FQN(
             scope_redirection_logic=my_scope_redirection_logic),
-                           glob_args=glob_args,
-                           search_path=search_path, importAs=importAs,
-                           importURI_converter=importURI_converter,
-                           importURI_to_scope_name=importURI_to_scope_name)
+            glob_args=glob_args,
+            search_path=search_path, importAs=importAs,
+            importURI_converter=importURI_converter,
+            importURI_to_scope_name=importURI_to_scope_name)
 
 
 class PlainNameImportURI(ImportURI):
@@ -573,8 +573,8 @@ class RelativeName(object):
                 "expected path to list in the model ({})".format(
                     self.path_to_container_object))
         obj_list = filter(
-            lambda x: textx_isinstance(x, attr.cls) and
-            x.name.find(name_part) >= 0, obj_list)
+            lambda x: textx_isinstance(x, attr.cls)
+            and x.name.find(name_part) >= 0, obj_list)
 
         return list(obj_list)
 
@@ -641,8 +641,8 @@ class ExtRelativeName(object):
                     "expected path to list in the model ({})".format(
                         self.path_to_target))
             tmp_list = list(filter(
-                lambda x: textx_isinstance(x, attr.cls) and
-                x.name.find(name_part) >= 0, tmp_list))
+                lambda x: textx_isinstance(x, attr.cls)
+                and x.name.find(name_part) >= 0, tmp_list))
             obj_list = obj_list + tmp_list
 
         return list(obj_list)

--- a/textx/scoping/tools.py
+++ b/textx/scoping/tools.py
@@ -5,7 +5,6 @@
 # License: MIT License
 #######################################################################
 from textx import get_children, get_model
-from textx.metamodel import _getattr
 import re
 
 
@@ -209,7 +208,7 @@ def resolve_model_path(obj, dot_separated_name,
         else:
             return None
     else:
-        next_obj = _getattr(obj, names[0])
+        next_obj = getattr(obj, names[0])
         if needs_to_be_resolved(obj, names[0]):
             return Postponed()
         elif next_obj is None:


### PR DESCRIPTION
I've been working today on a different approach to user obj. initialization postpone.

In order to support postponed initialization, user classes `*attr` methods are
patched during model loading and restored at the end just before `__init__`
methods are called.

Currently this isn't working if same user class is used in multiple meta-models
which depend on each other as the instrumentation is removed while still needed
for referring meta-model (please see test_issue140.py). Looks like the instrumentation should be extended to be local per model. @goto40 please take a look and see if this direction looks good to you.

This PR is based on ongoing #253, first commit is reverting calling `*attr` methods already merged to the feature branch and the second commit is the actual proposed change.

**EDIT**: I have also collected user class instances along the way, so no need for `get_children` call.

/cc @goto40 @markusschmaus

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
