### PR TITLE
Don't cache super class methods when replacing attr methods

### DIFF
--- a/tests/functional/test_user_class_attrs_frozen.py
+++ b/tests/functional/test_user_class_attrs_frozen.py
@@ -70,6 +70,14 @@ def test_inheritance_attrs():
     class Sub(Super):
         b = attr.ib()
 
+    super_getattribute = Super.__getattribute__
+    sub_getattribute = Sub.__getattribute__
+
     mm = metamodel_from_str(grammar, classes=[Super, Sub])
     model = mm.model_from_str(modelstr)
     assert model.sub.b == 'something'
+
+    # Make sure that the special methods of both classes have been correctly
+    # restored
+    assert Super.__getattribute__ == super_getattribute
+    assert Sub.__getattribute__ == sub_getattribute

--- a/textx/model.py
+++ b/textx/model.py
@@ -335,7 +335,7 @@ def get_model_parser(top_rule, comments_model, **kwargs):
                 real_name = '__{}__'.format(a_name)
                 cached_name = '_tx_real_{}'.format(a_name)
                 setattr(user_class, cached_name,
-                        getattr(user_class, real_name, None))
+                        user_class.__dict__.get(real_name, None))
                 setattr(user_class, real_name,
                         locals()['_{}'.format(a_name)])
             user_class._tx_instrumented = 1


### PR DESCRIPTION
<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated
- [x] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/

I noticed that when user classes inherited from each other, then the attrs methods weren't always correctly restored, which this PR fixes analogous to https://github.com/textX/textX/pull/256#discussion_r425743468