### PR TITLE
A more informative exception on unhashable name type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ please take a look at related PRs and issues and see if the change affects you.
   object that contained the lookup name in its name. Thanks ipa-mdl@GitHub
   ([#267])
 
+### Changed
+
+- Changed `unhashable type` exception when a list is used for `name` attributes by
+  raising a more informative exception and extending docs to document the issue
+  and a proper way to solve it ([#40], [#266]).
+
 
 ## [v2.2.0] (released: 2020-08-03)
 
@@ -465,6 +471,7 @@ please take a look at related PRs and issues and see if the change affects you.
 
 
 [#267]: https://github.com/textX/textX/issues/267
+[#266]: https://github.com/textX/textX/issues/266
 [#264]: https://github.com/textX/textX/pull/264
 [#261]: https://github.com/textX/textX/pull/261
 [#260]: https://github.com/textX/textX/pull/260
@@ -528,6 +535,7 @@ please take a look at related PRs and issues and see if the change affects you.
 [#96]: https://github.com/textX/textX/issues/96
 [#93]: https://github.com/textX/textX/pull/93
 [#92]: https://github.com/textX/textX/pull/92
+[#40]: https://github.com/textX/textX/issues/40
 
 [Unreleased]: https://github.com/textX/textX/compare/v2.2.0...HEAD
 [v2.2.0]: https://github.com/textX/textX/compare/v2.1.0...v2.2.0

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -496,7 +496,21 @@ assignments. There are two types of rule references:
 
     Attributes with `name` names are used for reference auto-resolving. A dict
     lookup is used, thus they must be of a hashable type. See 
-    [issue #40](https://github.com/textX/textX/issues/40).
+    issues [#40](https://github.com/textX/textX/issues/40) and 
+    [#266](https://github.com/textX/textX/issues/266).
+
+    A usual error is to match the name in this fashion:
+
+        MyObj: name+=ID['.'];
+
+    Here, `name` will be a list of strings that are separated by dot and that
+    will not work as the name must be hashable. The best way to implement this 
+    and make `name` hashable is:
+
+        MyObj: name=FQN;
+        FQN: ID+['.'];
+
+    Now, `name` will be the string returned by the `FQN` match rule.
 
 
 ### Syntactic predicates

--- a/textx/model.py
+++ b/textx/model.py
@@ -509,7 +509,15 @@ def parse_tree_to_objgraph(parser, parse_tree, file_name=None,
                 # Objects of each class are in its own namespace
                 if not id(inst.__class__) in parser._instances:
                     parser._instances[id(inst.__class__)] = {}
-                parser._instances[id(inst.__class__)][inst.name] = inst
+                try:
+                    parser._instances[id(inst.__class__)][inst.name] = inst
+                except TypeError as e:
+                    if 'unhashable type' in e.args[0]:
+                        raise TextXSemanticError(
+                            'Object name can\'t be of unhashable type.'
+                            ' Please see the note in this docs'
+                            ' section http://textx.github.io/textX/stable/grammar/#references')  # noqa
+                    raise
 
             if parser.debug:
                 parser.dprint("LEAVING INSTANCE {}".format(node.rule_name))


### PR DESCRIPTION
@goto40 This change adds a better exception message for #40 and #266. Also the docs is extended to better explain the issue and the right way to solve the problem.


Fix #40 #266 


## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
