### PR TITLE
Builtin models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Added
 
+  - `builtin_models` of type `ModelRepository` to meta-model constructor. Used
+    to supply pre-loaded models for `ImportURI` based scoping providers as a
+    fallback to search into. ([#284])
   - Initial implementation of TEP-001 ([#111]) allowing to specify scope
     provider behavior within the grammar itself. [#274] introduces
     the RREL (reference resolving expression language) to define how
@@ -493,6 +496,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#284]: https://github.com/textX/textX/pull/284
 [#283]: https://github.com/textX/textX/pull/283
 [#282]: https://github.com/textX/textX/pull/282
 [#281]: https://github.com/textX/textX/pull/281

--- a/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
@@ -15,8 +15,7 @@ def test_issue196_errors_in_scope_provider_and_obj_processor():
     #      _tx_model_repository.all_models.filename_to_model.keys())
 
     cached_model_count = len(
-        metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model)
+        metamodel_for_language('flow-dsl')._tx_model_repository.all_models)
 
     with pytest.raises(TextXError,
                        match=r'.*types must be lowercase.*'):
@@ -30,8 +29,7 @@ def test_issue196_errors_in_scope_provider_and_obj_processor():
 
     # error while reading, no file cached (cached_model_count unchanged)!
     assert cached_model_count == len(
-        metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model)
+        metamodel_for_language('flow-dsl')._tx_model_repository.all_models)
 
     with pytest.raises(TextXError,
                        match=r'.*Unknown object "A" of class "Algo".*'):
@@ -46,8 +44,7 @@ def test_issue196_errors_in_scope_provider_and_obj_processor():
 
     # error while reading, no file cached! (cached_model_count unchanged)!
     assert cached_model_count == len(
-        metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model)
+        metamodel_for_language('flow-dsl')._tx_model_repository.all_models)
 
     with pytest.raises(TextXError,
                        match=r'.*types must be lowercase.*'):
@@ -57,8 +54,7 @@ def test_issue196_errors_in_scope_provider_and_obj_processor():
 
     # error while reading, no file cached! (cached_model_count unchanged)!
     assert cached_model_count == len(
-        metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model)
+        metamodel_for_language('flow-dsl')._tx_model_repository.all_models)
 
 
 def test_issue196_syntax_error_1():
@@ -69,8 +65,7 @@ def test_issue196_syntax_error_1():
     #      _tx_model_repository.all_models.filename_to_model.keys())
 
     cached_model_count = len(
-        metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model)
+        metamodel_for_language('flow-dsl')._tx_model_repository.all_models)
 
     with pytest.raises(TextXError,
                        match=r'.*error: Expected.*'):
@@ -85,8 +80,7 @@ def test_issue196_syntax_error_1():
 
     # error while reading, no file cached!
     assert cached_model_count == len(
-        metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model)
+        metamodel_for_language('flow-dsl')._tx_model_repository.all_models)
 
 
 def test_issue196_syntax_error_2():
@@ -97,8 +91,7 @@ def test_issue196_syntax_error_2():
     #      _tx_model_repository.all_models.filename_to_model.keys())
 
     cached_model_count = len(
-        metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model)
+        metamodel_for_language('flow-dsl')._tx_model_repository.all_models)
 
     with pytest.raises(TextXError,
                        match=r'.*error: Expected.*'):
@@ -112,5 +105,4 @@ def test_issue196_syntax_error_2():
 
     # error while reading, no file cached! (cached_model_count unchanged)!
     assert cached_model_count == len(
-        metamodel_for_language('flow-dsl').
-        _tx_model_repository.all_models.filename_to_model)
+        metamodel_for_language('flow-dsl')._tx_model_repository.all_models)

--- a/tests/functional/test_metamodel/test_multi_metamodel_refs.py
+++ b/tests/functional/test_metamodel/test_multi_metamodel_refs.py
@@ -340,7 +340,7 @@ def test_multi_metamodel_types_data_flow1():
     # althought, types.type is included 2x, it is only present 1x
     # (scope providers share a common repo within on model and all
     #  loaded models in that model)
-    assert 3 == len(model1._tx_model_repository.all_models.filename_to_model)
+    assert 3 == len(model1._tx_model_repository.all_models)
 
     # load the type model also used by model1
     model2 = LibData.get_metamodel().model_from_file(
@@ -378,7 +378,7 @@ def test_multi_metamodel_types_data_flow2():
                      'data_flow.flow')
     )
     # althought, types.type is included 2x, it is only present 1x
-    assert 3 == len(model1._tx_model_repository.all_models.filename_to_model)
+    assert 3 == len(model1._tx_model_repository.all_models)
 
     # load the type model also used by model1
     model2 = LibData.get_metamodel().model_from_file(

--- a/tests/functional/test_scoping/test_builtin_models.py
+++ b/tests/functional/test_scoping/test_builtin_models.py
@@ -1,0 +1,38 @@
+from __future__ import unicode_literals
+
+from textx.scoping import ModelRepository
+from textx import metamodel_from_str, register_language
+
+
+types_mm = metamodel_from_str(r'''
+Model: types+=BaseType;
+BaseType: 'type' name=ID;
+''')
+
+entity_mm_str = r'''
+reference builtin_types as t
+Model: entities+=Entity;
+Entity: 'entity' name=ID '{'
+              properties*=Property
+        '}'
+;
+Property: name=ID ':' type=[t.BaseType|ID|+m:types];
+'''
+
+
+def test_builtin_models_are_searched_by_rrel():
+
+    register_language('builtin_types', '*.type', metamodel=types_mm)
+
+    builtin_models = ModelRepository()
+    builtin_models.add_model(types_mm.model_from_str('type int type bool'))
+
+    mm = metamodel_from_str(entity_mm_str, builtin_models=builtin_models)
+
+    model = mm.model_from_str(r'''
+    entity First {
+        first : bool
+    }
+    ''')
+    assert model.entities[0].properties[0].type.__class__.__name__ == 'BaseType'
+    assert model.entities[0].properties[0].type.name == 'bool'

--- a/tests/functional/test_scoping/test_global_import_modules.py
+++ b/tests/functional/test_scoping/test_global_import_modules.py
@@ -140,7 +140,7 @@ def test_globalimports_basic_test_with_distributed_model():
     #################################
 
     # check that "socket" is an interface
-    inner_model = my_model._tx_model_repository.all_models.filename_to_model[
+    inner_model = my_model._tx_model_repository.all_models[
         join(abspath(dirname(__file__)),
              "interface_model2", "model_b", "base.if")]
     check_unique_named_object_has_class(inner_model, "socket", "Interface")

--- a/tests/functional/test_scoping/test_import_module.py
+++ b/tests/functional/test_scoping/test_import_module.py
@@ -81,7 +81,7 @@ def test_model_with_imports():
     #################################
 
     # check that "socket" is an interface
-    inner_model = my_model._tx_model_repository.all_models.filename_to_model[
+    inner_model = my_model._tx_model_repository.all_models[
         join(abspath(dirname(__file__)),
              "interface_model1", "model_b", "base.if")]
     check_unique_named_object_has_class(inner_model, "socket", "Interface")

--- a/tests/functional/test_scoping/test_metamodel_provider2.py
+++ b/tests/functional/test_scoping/test_metamodel_provider2.py
@@ -69,7 +69,7 @@ def test_metamodel_provider_advanced_test():
 
     def get_all(model_repo, what):
         lst = []
-        for m in model_repo.filename_to_model.values():
+        for m in model_repo:
             lst = lst + get_children_of_type(what, m)
         return lst
 

--- a/tests/functional/test_scoping/test_metamodel_provider3.py
+++ b/tests/functional/test_scoping/test_metamodel_provider3.py
@@ -77,7 +77,7 @@ def test_metamodel_provider_advanced_test3_global():
 
     def get_all(model_repo, what):
         lst = []
-        for m in model_repo.filename_to_model.values():
+        for m in model_repo:
             lst = lst + get_children_of_type(what, m)
         return lst
 
@@ -170,7 +170,7 @@ def test_metamodel_provider_advanced_test3_import():
 
     def get_all(model_repo, what):
         lst = []
-        for m in model_repo.filename_to_model.values():
+        for m in model_repo:
             lst = lst + get_children_of_type(what, m)
         return lst
 
@@ -261,7 +261,7 @@ def test_metamodel_provider_advanced_test3_inheritance():
 
     def get_all(model_repo, what):
         lst = []
-        for m in model_repo.filename_to_model.values():
+        for m in model_repo:
             lst = lst + get_children_of_type(what, m)
         return lst
 
@@ -345,7 +345,7 @@ def test_metamodel_provider_advanced_test3_inheritance2():
 
     def get_all(model_repo, what):
         lst = []
-        for m in model_repo.filename_to_model.values():
+        for m in model_repo:
             lst = lst + get_children_of_type(what, m)
         return lst
 
@@ -358,7 +358,7 @@ def test_metamodel_provider_advanced_test3_inheritance2():
 
     # check that all models have different parsers
     parsers = list(
-        map(lambda x: x._tx_parser, model_repo.filename_to_model.values()))
+        map(lambda x: x._tx_parser, model_repo))
     assert 4 == len(parsers)  # 4 files -> 4 parsers
     assert 4 == len(set(parsers))  # 4 different parsers
 
@@ -436,7 +436,7 @@ def test_metamodel_provider_advanced_test3_diamond():
 
     def get_all(model_repo, what):
         lst = []
-        for m in model_repo.filename_to_model.values():
+        for m in model_repo:
             lst = lst + get_children_of_type(what, m)
         return lst
 
@@ -448,8 +448,7 @@ def test_metamodel_provider_advanced_test3_diamond():
         assert a.method
 
     # check that all models have different parsers
-    parsers = list(
-        map(lambda x: x._tx_parser, model_repo.filename_to_model.values()))
+    parsers = list(map(lambda x: x._tx_parser, model_repo))
     assert 4 == len(parsers)  # 4 files -> 4 parsers
     assert 4 == len(set(parsers))  # 4 different parsers
 

--- a/tests/functional/test_scoping/test_metamodel_provider3_custom_classes.py
+++ b/tests/functional/test_scoping/test_metamodel_provider3_custom_classes.py
@@ -93,7 +93,7 @@ def test_metamodel_provider_advanced_test3_global():
 
     def get_all(model_repo, what):
         lst = []
-        for m in model_repo.filename_to_model.values():
+        for m in model_repo:
             lst = lst + get_children_of_type(what, m)
         return lst
 
@@ -186,7 +186,7 @@ def test_metamodel_provider_advanced_test3_import():
 
     def get_all(model_repo, what):
         lst = []
-        for m in model_repo.filename_to_model.values():
+        for m in model_repo:
             lst = lst + get_children_of_type(what, m)
         return lst
 
@@ -277,7 +277,7 @@ def test_metamodel_provider_advanced_test3_inheritance():
 
     def get_all(model_repo, what):
         lst = []
-        for m in model_repo.filename_to_model.values():
+        for m in model_repo:
             lst = lst + get_children_of_type(what, m)
         return lst
 
@@ -361,7 +361,7 @@ def test_metamodel_provider_advanced_test3_inheritance2():
 
     def get_all(model_repo, what):
         lst = []
-        for m in model_repo.filename_to_model.values():
+        for m in model_repo:
             lst = lst + get_children_of_type(what, m)
         return lst
 
@@ -373,8 +373,7 @@ def test_metamodel_provider_advanced_test3_inheritance2():
         assert a.method
 
     # check that all models have different parsers
-    parsers = list(
-        map(lambda x: x._tx_parser, model_repo.filename_to_model.values()))
+    parsers = list(map(lambda x: x._tx_parser, model_repo))
     assert 4 == len(parsers)  # 4 files -> 4 parsers
     assert 4 == len(set(parsers))  # 4 different parsers
 
@@ -452,7 +451,7 @@ def test_metamodel_provider_advanced_test3_diamond():
 
     def get_all(model_repo, what):
         lst = []
-        for m in model_repo.filename_to_model.values():
+        for m in model_repo:
             lst = lst + get_children_of_type(what, m)
         return lst
 
@@ -464,8 +463,7 @@ def test_metamodel_provider_advanced_test3_diamond():
         assert a.method
 
     # check that all models have different parsers
-    parsers = list(
-        map(lambda x: x._tx_parser, model_repo.filename_to_model.values()))
+    parsers = list(map(lambda x: x._tx_parser, model_repo))
     assert 4 == len(parsers)  # 4 files -> 4 parsers
     assert 4 == len(set(parsers))  # 4 different parsers
 

--- a/textx/export.py
+++ b/textx/export.py
@@ -404,7 +404,7 @@ def model_export_to_file(f, model=None, repo=None):
     if repo or hasattr(model, "_tx_model_repository"):
         if not repo:
             repo = model._tx_model_repository.all_models
-        for m in repo.filename_to_model.values():
+        for m in repo:
             _export_subgraph(m)
             _export(m)
     else:

--- a/textx/metamodel.py
+++ b/textx/metamodel.py
@@ -128,6 +128,9 @@ class TextXMetaModel(DebugPrinter):
         builtins(dict): A dict of named object used in linking phase.
             References to named objects not defined in the model will be
             searched here.
+        builtin_models(ModelRepository): An optional repository of preloaded models
+            to be used during reference resolving. These models will be searched
+            as a fallback before `builtins`.
         classes(list of classes or callable): A list of user supplied classes
             to use instead of the dynamically created or a callable providing
             those classes. The callable must accept a rule name and return a
@@ -160,9 +163,10 @@ class TextXMetaModel(DebugPrinter):
     """
 
     def __init__(self, file_name=None, classes=None, builtins=None,
-                 auto_init_attributes=True, ignore_case=False, skipws=True,
-                 ws=None, autokwd=False, memoization=False,
-                 textx_tools_support=False, use_regexp_group=False, **kwargs):
+                 builtin_models=None, auto_init_attributes=True,
+                 ignore_case=False, skipws=True, ws=None, autokwd=False,
+                 memoization=False, textx_tools_support=False,
+                 use_regexp_group=False, **kwargs):
         # evaluate optional parameter "global_repository"
         global_repository = kwargs.pop("global_repository", False)
         if global_repository:
@@ -182,6 +186,7 @@ class TextXMetaModel(DebugPrinter):
         self.rootcls = None
 
         self.builtins = builtins
+        self.builtin_models = builtin_models
 
         # Convert classes to dict for easier lookup
         self.user_classes = {}

--- a/textx/metamodel.py
+++ b/textx/metamodel.py
@@ -654,13 +654,11 @@ class TextXMetaModel(DebugPrinter):
                     # print("METAMODEL PRE-CALLBACK => {}".format(filename))
                     other_model._tx_model_repository = GlobalModelRepository(
                         self._tx_model_repository.all_models)
-                    self._tx_model_repository.all_models\
-                        .filename_to_model[filename] = other_model
+                    self._tx_model_repository.all_models[filename] = other_model
 
                 callback = _pre_ref_resolution_callback
             if self._tx_model_repository.all_models.has_model(file_name):
-                model = self._tx_model_repository.all_models\
-                    .filename_to_model[file_name]
+                model = self._tx_model_repository.all_models[file_name]
 
         def kwargs_callback(other_model):
             if hasattr(other_model, '_tx_metamodel'):

--- a/textx/scoping/__init__.py
+++ b/textx/scoping/__init__.py
@@ -41,10 +41,19 @@ class ModelRepository(object):
     """
 
     def __init__(self):
+        self.name_idx = 1
         self.filename_to_model = {}
 
     def has_model(self, filename):
         return abspath(filename) in self.filename_to_model
+
+    def add_model(self, model):
+        if model._tx_filename:
+            filename = abspath(model._tx_filename)
+        else:
+            filename = 'builtin_model_{}'.format(self.name_idx)
+            self.name_idx += 1
+        self.filename_to_model[filename] = model
 
     def remove_model(self, model):
         filename = None

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -371,6 +371,13 @@ class ImportURI(scoping.ModelLoader):
             ret = self.scope_provider(m, attr, obj_ref)
             if ret:
                 return ret
+
+        # 3) Use builtin models as a fallback if provided
+        if model._tx_metamodel.builtin_models:
+            for m in model._tx_metamodel.builtin_models:
+                ret = self.scope_provider(m, attr, obj_ref)
+                if ret:
+                    return ret
         return None
 
 

--- a/textx/scoping/providers.py
+++ b/textx/scoping/providers.py
@@ -367,7 +367,7 @@ class ImportURI(scoping.ModelLoader):
             return ret
 
         # 2) do we have loaded models?
-        for m in model_repository.local_models.filename_to_model.values():
+        for m in model_repository.local_models:
             ret = self.scope_provider(m, attr, obj_ref)
             if ret:
                 return ret

--- a/textx/scoping/rrel.py
+++ b/textx/scoping/rrel.py
@@ -352,6 +352,7 @@ class RRELPath(RRELBase):
 
     def get_next_matches(self, obj, lookup_list, allowed, first_element=False):
         from textx.scoping import Postponed
+
         def intern_get_next_matches(obj, lookup_list, allowed, first_element=False,
                                     idx=0):
             assert len(self.path_elements) > idx

--- a/textx/scoping/tools.py
+++ b/textx/scoping/tools.py
@@ -232,8 +232,7 @@ def get_unique_named_object_in_all_models(root, name):
         the object (if not unique, raises an error)
     """
     if hasattr(root, '_tx_model_repository'):
-        src = list(
-            root._tx_model_repository.local_models.filename_to_model.values())
+        src = list(root._tx_model_repository.local_models)
         if root not in src:
             src.append(root)
     else:


### PR DESCRIPTION
This PR has two commit. First commit is simplification of model repo access. Second commit is a new feature that adds `builtin_models` param to meta-model which serves similar purpose as `builtins` but is of `ModelRepository` type and enables adding a regular textX models as a fallback for all `ImportURI` based scoping providers.

I'm working on a language where I have two meta-models. One is intended for end-user while the other is internal meta-model used to specify types/object referenced from the user's models. I wanted to free users of having to import these provided specifications. Actually, those spec would be deployed by the language library so it would be hard for users to know their locations, thus it is nice to be able to pre-load those specs during main meta-model construction.

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
