### PR TITLE
Add support for RRELs in textX meta-spec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ please take a look at related PRs and issues and see if the change affects you.
     to supply pre-loaded models for `ImportURI` based scoping providers as a
     fallback to search into. ([#284])
   - Initial implementation of TEP-001 ([#111]) allowing to specify scope
-    provider behavior within the grammar itself. [#274] introduces
+    provider behavior within the grammar itself. [#274] and [#287] introduce
     the RREL (reference resolving expression language) to define how
     references are resolved. Details see `rrel.md`.
   - Parameter `should_follow` of callable type to `get_children` and
@@ -496,6 +496,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#287]: https://github.com/textX/textX/pull/287
 [#284]: https://github.com/textX/textX/pull/284
 [#283]: https://github.com/textX/textX/pull/283
 [#282]: https://github.com/textX/textX/pull/282

--- a/tests/functional/textx_textx/test_textx_rrel.py
+++ b/tests/functional/textx_textx/test_textx_rrel.py
@@ -1,0 +1,27 @@
+from __future__ import unicode_literals
+from os.path import join, abspath, dirname
+from textx import metamodel_for_language, get_children_of_type
+
+
+def test_textx_rrel_multi():
+
+    textx_mm = metamodel_for_language('textx')
+    grammar_model = textx_mm.grammar_model_from_file(
+        join(abspath(dirname(__file__)), 'textx_rrel_test.tx'))
+
+    rrels = get_children_of_type('RRELExpression', grammar_model)
+
+    # Multi
+    assert rrels[0].multi
+
+    # Multi with parent
+    assert rrels[1].multi \
+        and rrels[1].sequence.paths[0].parts[0].__class__.__name__ == 'RRELParent'
+
+    # Dots
+    dots = get_children_of_type('RRELPath', rrels[3])
+    assert any([x.dots == '..' for x in dots])
+
+    # Brackets
+    brackets = get_children_of_type('RRELBrackets', rrels[4])
+    assert len(brackets) == 1

--- a/tests/functional/textx_textx/textx_rrel_test.tx
+++ b/tests/functional/textx_textx/textx_rrel_test.tx
@@ -1,0 +1,12 @@
+/* Grammar for testing textX RREL parsing
+    This grammar is loaded for analysis, thus references and RREL expressions
+    are just syntactically valid to assert that grammar_model_from_file can
+    properly parse RRELs.
+*/
+
+Multi: ref=[Target|ID|+m:^some_rule];
+MultiParent: ref=[Target|ID|+m:parent(SomeType).some_rule];
+Parent: ref=[Target|ID|parent(SomeRule).obj.ref.~extension*.methods];
+Dots: ref=[Target|ID|(..)*.(pkg)*.cls];
+Brackets: ref=[Target|ID|obj.ref.(~extension)*.methods];
+WhiteSpace: ref=[Target|ID|obj. ref.(~extension ) *. methods];

--- a/textx/textx.tx
+++ b/textx/textx.tx
@@ -124,12 +124,25 @@ BuiltinRuleRef:
 ;
 
 ObjRef: // TODO: add RREL
-    '[' name=ClassName ('|' obj_ref_rule=ID)? ']'
+    '[' name=ClassName ('|' obj_ref_rule=ID ('|' rrel=RRELExpression))? ']'
 ;
 
 ClassName:
     QualifiedIdent
 ;
+
+
+// RREL
+RRELExpression: multi?="+m:" sequence=RRELSequence;
+RRELSequence: paths+=RRELPath[','];
+RRELPath: (up='^' | dots=RRELDots)? parts*=RRELPathPart['.'];
+RRELPathPart: RRELZeroOrMore | RRELPathElement;
+RRELZeroOrMore: element=RRELPathElement '*';
+RRELPathElement: RRELParent | RRELBrackets | RRELNavigation;
+RRELDots: /\.+/;
+RRELBrackets: '(' sequence=RRELSequence ')';
+RRELNavigation: noconsume?='~' attr=ID;
+RRELParent: 'parent' '(' type=ID ')';
 
 
 QualifiedIdent:


### PR DESCRIPTION
Enables loading of grammars which use RRELs with `grammar_model_from_file`

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
