### PR TITLE
Fix following of Falsy elements in `get_children`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Fixed
 
+  - Fixed bug with Falsy user classes in `get_children` ([#288])
   - Fixed bug with unhashable objects during dot export ([#283])
   - Fixed bug where (Ext)RelativeName scope providers accepted any referenced
     object that contained the lookup name in its name. Thanks ipa-mdl@GitHub
@@ -496,6 +497,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#288]: https://github.com/textX/textX/pull/288
 [#284]: https://github.com/textX/textX/pull/284
 [#283]: https://github.com/textX/textX/pull/283
 [#282]: https://github.com/textX/textX/pull/282

--- a/textx/model.py
+++ b/textx/model.py
@@ -100,7 +100,7 @@ def get_children(selector, root, children_first=False, should_follow=lambda obj:
                 if attr.cont:
                     if attr.mult in (MULT_ONE, MULT_OPTIONAL):
                         new_elem = getattr(elem, attr_name)
-                        if new_elem and should_follow(new_elem):
+                        if new_elem is not None and should_follow(new_elem):
                             follow(new_elem)
                     else:
                         new_elem_list = getattr(elem, attr_name)


### PR DESCRIPTION
The problem can arise if user classes are used which can evaluate to `False` in
boolean contexts.

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
