### PR TITLE
Fix export when all_models is empty

### DIFF
--- a/textx/export.py
+++ b/textx/export.py
@@ -404,6 +404,8 @@ def model_export_to_file(f, model=None, repo=None):
     if repo or hasattr(model, "_tx_model_repository"):
         if not repo:
             repo = model._tx_model_repository.all_models
+            if not repo:
+                _export(model)
         for m in repo:
             _export_subgraph(m)
             _export(m)


### PR DESCRIPTION
This may happen if `builtin_models` is used but not global repo. In this case `all_models` can be empty which will result in empty dot file produced.

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
