### PR TITLE
Reorganize docs navigation sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,21 +11,26 @@ extra_css: [style.css, css/version-select.css]
 nav:
 - Home: index.md
 - User Guide:
-  - Grammar: grammar.md
-  - Meta-model: metamodel.md
-  - Model: model.md
-  - Scoping: scoping.md
-  - Reference resolving expression language: rrel.md
-  - Multi meta-model: multimetamodel.md
-  - Parser configuration: parser_config.md
-  - Registration/Discovery: registration.md
-  - Visualization: visualization.md
-  - Error handling: error_handling.md
-  - Debugging: debugging.md
-  - textx command: textx_command.md
-  - Project scaffolding: scaffolding.md
-  - Jinja generators: jinja.md
-  - Howtos: howto.md
+  - Basics:
+    - Hello world: tutorials/hello_world.md
+    - Grammar: grammar.md
+    - Meta-model: metamodel.md
+    - Model: model.md
+    - Parser configuration: parser_config.md
+    - textx command: textx_command.md
+    - Registration/Discovery: registration.md
+    - Visualization: visualization.md
+    - Project scaffolding: scaffolding.md
+    - Howtos: howto.md
+  - Scoping and multi-file:
+    - Scoping: scoping.md
+    - Reference resolving expression language (RREL): rrel.md
+    - Multi meta-model: multimetamodel.md
+  - Errors:
+    - Error handling: error_handling.md
+    - Debugging: debugging.md
+  - Generators:
+    - Jinja generators: jinja.md
 - Tutorials:
   - Hello World: tutorials/hello_world.md
   - Robot: tutorials/robot.md


### PR DESCRIPTION
@goto40 here is a proposal to slightly reorganized docs sidebar navigation to be more approachable. What's your thought?

It looks like this

![image](https://user-images.githubusercontent.com/1673425/96906810-a6bf3500-149a-11eb-8add-5741e3fb3143.png)


## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
