### PR TITLE
Refactor: change _tx_model_param_defitions -> model_param_defs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Changed
 
+  - `_tx_model_param_definitions` deprecated in favor of `model_param_defs` ([#298]).
   - `click` is now an optional dependency, only when CLI is needed ([#292])
   - Make warning about not overwriting generated file more visible
     ([01341ec3](https://github.com/textX/textX/commit/01341ec381bfb4c8c27bcec5d2998a34d207f430))
@@ -500,6 +501,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#298]: https://github.com/textX/textX/pull/298
 [#294]: https://github.com/textX/textX/pull/294
 [#292]: https://github.com/textX/textX/pull/292
 [#288]: https://github.com/textX/textX/pull/288

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -335,15 +335,15 @@ RHS object is not matched in the input. The multiplicity assignments (`*=` and
 
 ## Optional model parameter definitions
 
-A meta-model can define optional model parameters. Such definitions
-are stored in `_tx_model_param_definitions` and define optional parameters,
-which can be specified while loading/creating a model through `model_from_str`
-or `model_from_file`. Details: see [tx_model_params](model.md#_tx_model_params).
+A meta-model can define optional model parameters. Such definitions are stored
+in `model_param_defs` and define optional parameters, which can be specified
+while loading/creating a model through `model_from_str` or `model_from_file`.
+Details: see [tx_model_params](model.md#_tx_model_params).
 
-`metamodel._tx_model_param_definitions` can be queried (like a dict) to
-retrieve possible extra parameters and their descriptions for a meta-model.
-It is also used to restrict the additional parameters passed to
-`model_from_str` or `model_from_file`.
+`metamodel.model_param_defs` can be queried (like a dict) to retrieve possible
+extra parameters and their descriptions for a meta-model. It is also used to
+restrict the additional parameters passed to `model_from_str` or
+`model_from_file`.
 
 Default parameters are:
 

--- a/docs/model.md
+++ b/docs/model.md
@@ -218,6 +218,6 @@ instances (see textx.scoping.providers).
 
 This attribute always exists. It holds all additional parameters passed to
 `model_from_str` or `model_from_file` of a metamodel. These parameters are
-restricted by the `metamodel._tx_model_param_definitions` object
-([model and object processors](metamodel.md#optional-model-parameter-definitions)),
-which is controlled by the metamodel designer.
+restricted by the `metamodel.model_param_defs` object ([model and object
+processors](metamodel.md#optional-model-parameter-definitions)), which is
+controlled by the metamodel designer.

--- a/tests/functional/registration/projects/types_dsl/types_dsl/__init__.py
+++ b/tests/functional/registration/projects/types_dsl/types_dsl/__init__.py
@@ -10,7 +10,7 @@ def types_dsl():
     current_dir = os.path.dirname(__file__)
     p = os.path.join(current_dir, 'Types.tx')
     types_mm = metamodel_from_file(p, global_repository=True)
-    types_mm._tx_model_param_definitions.add(
+    types_mm.model_param_defs.add(
         'type_name_check',
         'enables checks on the type name (default="on" or "off")'
     )

--- a/tests/functional/test_metamodel/test_model_params.py
+++ b/tests/functional/test_metamodel/test_model_params.py
@@ -16,10 +16,10 @@ MyModel test1
 
 def test_model_params():
     mm = metamodel_from_str(grammar)
-    mm._tx_model_param_definitions.add(
+    mm.model_param_defs.add(
         "parameter1", "an example param (1)"
     )
-    mm._tx_model_param_definitions.add(
+    mm.model_param_defs.add(
         "parameter2", "an example param (2)"
     )
 
@@ -53,19 +53,19 @@ def test_model_params():
     with raises(TextXError, match=".*unknown parameter myerror2.*"):
         mm.model_from_str(text, parameter1='P1', myerror2='P2')
 
-    assert len(mm._tx_model_param_definitions) >= 2
-    assert 'parameter1' in mm._tx_model_param_definitions
-    assert 'parameter1' in mm._tx_model_param_definitions
-    assert mm._tx_model_param_definitions[
+    assert len(mm.model_param_defs) >= 2
+    assert 'parameter1' in mm.model_param_defs
+    assert 'parameter1' in mm.model_param_defs
+    assert mm.model_param_defs[
         'parameter1'].description == "an example param (1)"
 
 
 def test_model_params_empty():
     mm = metamodel_from_str(grammar)
-    mm._tx_model_param_definitions.add(
+    mm.model_param_defs.add(
         "parameter1", "an example param (1)"
     )
-    mm._tx_model_param_definitions.add(
+    mm.model_param_defs.add(
         "parameter2", "an example param (2)"
     )
 
@@ -79,10 +79,10 @@ def test_model_params_empty():
 
 def test_model_params_file_based():
     mm = metamodel_from_str(grammar)
-    mm._tx_model_param_definitions.add(
+    mm.model_param_defs.add(
         "parameter1", "an example param (1)"
     )
-    mm._tx_model_param_definitions.add(
+    mm.model_param_defs.add(
         "parameter2", "an example param (2)"
     )
 

--- a/textx/metamodel.py
+++ b/textx/metamodel.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import codecs
 import os
 import sys
+import warnings
 from os.path import join, abspath, dirname
 from collections import OrderedDict
 from arpeggio import DebugPrinter
@@ -180,9 +181,8 @@ class TextXMetaModel(DebugPrinter):
 
         super(TextXMetaModel, self).__init__(**kwargs)
 
-        self._tx_model_param_definitions = ModelParamDefinitions()
-        self._tx_model_param_definitions.add(
-            "project_root", "the project root path")
+        self.model_param_defs = ModelParamDefinitions()
+        self.model_param_defs.add("project_root", "the project root path")
 
         self.file_name = file_name
         self.rootcls = None
@@ -600,7 +600,7 @@ class TextXMetaModel(DebugPrinter):
                 is set while executing pre_ref_resolution_callback (see
                 scoping.md)
         """
-        self._tx_model_param_definitions.check_params('from_str', **kwargs)
+        self.model_param_defs.check_params('from_str', **kwargs)
 
         if type(model_str) is not text:
             raise TextXError("textX accepts only unicode strings.")
@@ -629,7 +629,7 @@ class TextXMetaModel(DebugPrinter):
 
     def model_from_file(self, file_name, encoding='utf-8', debug=None,
                         **kwargs):
-        self._tx_model_param_definitions.check_params(file_name, **kwargs)
+        self.model_param_defs.check_params(file_name, **kwargs)
 
         return self.internal_model_from_file(
             file_name, encoding, debug,
@@ -710,6 +710,12 @@ class TextXMetaModel(DebugPrinter):
         """
         self.obj_processors = obj_processors
         self.type_convertors.update(obj_processors)
+
+    @property
+    def _tx_model_param_definitions(self):
+        warnings.warn(
+            '_tx_model_param_definitions is deprecated in favor of model_param_defs.')
+        return self.model_param_defs
 
 
 class TextXMetaMetaModel(object):


### PR DESCRIPTION
We use `_tx_` prefix for meta-data kept on model object to prevent name-clashing with user attributes. 
Since this attribute is on meta-model object there is not need for the prefix. This will make things more consistent as other attributes have no prefix (e.g. `builtins`, `user_classes` etc.).

I've also shortened name a bit.


## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
