### PR TITLE
Add extraction of model params in CLI generate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Added
 
+  - `textx generate`. Documented passing in arbitrary parameters which can be
+    used in the generator function. Also, implemented passing of model
+    parameters defined in the meta-model (`model_param_defs` and
+    `_tx_model_params`) ([#299])
   - `get_location` function for producing `line/col/filename` from any textX
     object. ([#294])
   - `builtin_models` of type `ModelRepository` to meta-model constructor. Used
@@ -501,6 +505,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#299]: https://github.com/textX/textX/pull/299
 [#298]: https://github.com/textX/textX/pull/298
 [#294]: https://github.com/textX/textX/pull/294
 [#292]: https://github.com/textX/textX/pull/292

--- a/docs/registration.md
+++ b/docs/registration.md
@@ -356,6 +356,28 @@ Options:
 
 ```
 
+You can pass in arbitrary parameters in the `generator` command. These
+parameters will get collected and will be made available as `kwargs` to the
+generator function call.
+
+For example:
+
+    textx generate mymodel.flow --target mytarget --overwrite --meaning_of_life 42
+    
+Your generator function:
+
+    @generator('flow', 'mytarget')
+    def flow_mytarget_generator(metamodel, model, output_path, overwrite, debug, **kwargs):
+        ... kwargs has meaning_of_life param
+        
+gets `meaning_of_life` param with value `42`.
+
+If you have [model parameters
+defined](metamodel.md#optional-model-parameter-definitions) on a meta-model
+then any parameter passed to the generator that is registered on the meta-model
+will be available as `model._tx_model_params` and can be used e.g. in [model
+processors](metamodel.md#model-processors).
+
 
 ## Registration API
 

--- a/tests/functional/test_metamodel/model_param_generate_test.mpt
+++ b/tests/functional/test_metamodel/model_param_generate_test.mpt
@@ -1,0 +1,1 @@
+MyModel justTesting

--- a/tests/functional/test_metamodel/test_model_params.py
+++ b/tests/functional/test_metamodel/test_model_params.py
@@ -1,8 +1,14 @@
 from __future__ import unicode_literals
-from textx import (metamodel_from_str)
+
+from click.testing import CliRunner
 import os.path
 from pytest import raises
+
+from textx import metamodel_from_str
+from textx.cli import textx
 from textx.exceptions import TextXError
+from textx.generators import gen_file, get_output_filename
+from textx import language, generator, register_language, register_generator
 
 
 grammar = r"""
@@ -94,3 +100,66 @@ def test_model_params_file_based():
     assert m.name == 'file_based'
     assert hasattr(m, '_tx_model_params')
     assert len(m._tx_model_params) == 2
+
+
+def test_model_params_generate_cli():
+    """
+    Test that model parameters are passed through generate cli command.
+    """
+
+    # register test language
+    @language('testlang', '*.mpt')
+    def model_param_test():
+
+        def processor(model, metamodel):
+            # Just to be sure that processor sees the model parameters
+            model.model_params = model._tx_model_params
+
+        mm = metamodel_from_str(grammar)
+        mm.model_param_defs.add('meaning_of_life', 'The Meaning of Life')
+        mm.register_model_processor(processor)
+        return mm
+    register_language(model_param_test)
+
+    # register language generator
+    @generator('testlang', 'testtarget')
+    def mytarget_generator(metamodel, model, output_path, overwrite,
+                           debug=False, **custom_args):
+
+        # Dump custom args for testing
+        txt = '\n'.join(["{}={}".format(arg_name, arg_value)
+                         for arg_name, arg_value in custom_args.items()])
+
+        # Dump model params processed by model processor for testing
+        txt += '\nModel params:'
+        txt += '\n'.join(["{}={}".format(param_name, param_value)
+                          for param_name, param_value in model.model_params.items()])
+
+        output_file = get_output_filename(model._tx_filename, None, 'testtarget')
+
+        def gen_callback():
+            with open(output_file, 'w') as f:
+                f.write(txt)
+        gen_file(model._tx_filename, output_file, gen_callback, overwrite)
+
+    register_generator(mytarget_generator)
+
+    # Run generator from CLI
+    this_folder = os.path.abspath(os.path.dirname(__file__))
+    runner = CliRunner()
+    model_file = os.path.join(this_folder, 'model_param_generate_test.mpt')
+    result = runner.invoke(textx, ['generate',
+                                   '--language', 'testlang',
+                                   '--target', 'testtarget',
+                                   '--overwrite', model_file,
+                                   '--meaning_of_life', '42',
+                                   '--someparam', 'somevalue'])
+
+    assert result.exit_code == 0
+
+    output_file = os.path.join(this_folder, 'model_param_generate_test.testtarget')
+    with open(output_file, 'r') as f:
+        content = f.read()
+
+    assert 'someparam=somevalue' in content
+    assert 'Model params:meaning_of_life=42' in content

--- a/textx/cli/generate.py
+++ b/textx/cli/generate.py
@@ -105,7 +105,13 @@ def generate(textx):
                 if per_file_metamodel:
                     language = language_for_file(model_file).name
                     metamodel = metamodel_for_file(model_file)
-                model = metamodel.model_from_file(model_file)
+
+                # Get custom args that match defined model parameters and pass
+                # them in to be available to model processors.
+                model_params = {k: v for k, v in custom_args.items()
+                                if k in metamodel.model_param_defs}
+
+                model = metamodel.model_from_file(model_file, **model_params)
                 generator = generator_for_language_target(
                     language, target, any_permitted=per_file_metamodel)
 


### PR DESCRIPTION
This change adds:

- Docs for arbitrary params to `textx generate`
- `textx generate` params which are recognized as model params registered on
  meta-model (`model_param_defs`) are passed to model construction and are
  available to model processors.

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
