### PR TITLE
Model export to dot if textX is replaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Added
 ### Fixed
+
+- Fixed model export to dot in cases where textX object is replaced in the
+  processor([#301])
+
 ### Changed
 
 
@@ -513,6 +517,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#301]: https://github.com/textX/textX/issues/301
 [#299]: https://github.com/textX/textX/pull/299
 [#298]: https://github.com/textX/textX/pull/298
 [#294]: https://github.com/textX/textX/pull/294

--- a/textx/export.py
+++ b/textx/export.py
@@ -334,56 +334,57 @@ def model_export_to_file(f, model=None, repo=None):
         attrs = ""
         obj_cls = obj.__class__
         name = ""
-        for attr_name, attr in obj_cls._tx_attrs.items():
+        if hasattr(obj_cls, '_tx_attrs'):
+            for attr_name, attr in obj_cls._tx_attrs.items():
 
-            attr_value = getattr(obj, attr_name)
-            if attr_value is None:
-                continue
+                attr_value = getattr(obj, attr_name)
+                if attr_value is None:
+                    continue
 
-            endmark = 'arrowtail=diamond dir=both' if attr.cont else ""
-            required = "+" if attr.mult in \
-                [MULT_ONE, MULT_ONEORMORE] else ""
+                endmark = 'arrowtail=diamond dir=both' if attr.cont else ""
+                required = "+" if attr.mult in \
+                    [MULT_ONE, MULT_ONEORMORE] else ""
 
-            if attr.mult in [MULT_ONEORMORE, MULT_ZEROORMORE]:
-                if all([type(x) in PRIMITIVE_PYTHON_TYPES
-                        for x in attr_value]):
-                    attrs += "{}{}:list=[".format(required, attr_name)
-                    attrs += ",".join([dot_repr(x) for x in attr_value])
-                    attrs += "]\\l"
-                else:
-                    for idx, list_obj in enumerate(attr_value):
-                        if list_obj is not None:
-                            if type(list_obj) in PRIMITIVE_PYTHON_TYPES:
-                                f.write(
-                                    '{} -> "{}:{}" [label="{}:{}" {}]\n'
-                                    .format(id(obj), list_obj,
-                                            type(list_obj).__name__,
-                                            attr_name, idx, endmark))
-                            else:
-                                f.write('{} -> {} [label="{}:{}" {}]\n'
-                                        .format(id(obj), id(list_obj),
-                                                attr_name, idx, endmark))
-                                _export(list_obj)
-            else:
-
-                # Plain attributes
-                if type(attr_value) is text and attr_name != 'name':
-                    attr_value = dot_repr(attr_value)
-
-                if type(attr_value) in PRIMITIVE_PYTHON_TYPES:
-                    if attr_name == 'name':
-                        name = attr_value
+                if attr.mult in [MULT_ONEORMORE, MULT_ZEROORMORE]:
+                    if all([type(x) in PRIMITIVE_PYTHON_TYPES
+                            for x in attr_value]):
+                        attrs += "{}{}:list=[".format(required, attr_name)
+                        attrs += ",".join([dot_repr(x) for x in attr_value])
+                        attrs += "]\\l"
                     else:
-                        attrs += "{}{}:{}={}\\l".format(
-                            required, attr_name, type(attr_value)
-                            .__name__, attr_value)
+                        for idx, list_obj in enumerate(attr_value):
+                            if list_obj is not None:
+                                if type(list_obj) in PRIMITIVE_PYTHON_TYPES:
+                                    f.write(
+                                        '{} -> "{}:{}" [label="{}:{}" {}]\n'
+                                        .format(id(obj), list_obj,
+                                                type(list_obj).__name__,
+                                                attr_name, idx, endmark))
+                                else:
+                                    f.write('{} -> {} [label="{}:{}" {}]\n'
+                                            .format(id(obj), id(list_obj),
+                                                    attr_name, idx, endmark))
+                                    _export(list_obj)
                 else:
-                    # Object references
-                    if attr_value is not None:
-                        f.write('{} -> {} [label="{}" {}]\n'.format(
-                            id(obj), id(attr_value),
-                            attr_name, endmark))
-                        _export(attr_value)
+
+                    # Plain attributes
+                    if type(attr_value) is text and attr_name != 'name':
+                        attr_value = dot_repr(attr_value)
+
+                    if type(attr_value) in PRIMITIVE_PYTHON_TYPES:
+                        if attr_name == 'name':
+                            name = attr_value
+                        else:
+                            attrs += "{}{}:{}={}\\l".format(
+                                required, attr_name, type(attr_value)
+                                .__name__, attr_value)
+                    else:
+                        # Object references
+                        if attr_value is not None:
+                            f.write('{} -> {} [label="{}" {}]\n'.format(
+                                id(obj), id(attr_value),
+                                attr_name, endmark))
+                            _export(attr_value)
 
         name = "{}:{}".format(name, obj_cls.__name__)
 


### PR DESCRIPTION
Fix #301 

This is a simple fix. If `_tx_attrs` are not available (e.g. object created outside of textX) we'll just ignore them (I have no idea if we can do any better, or should we?)


## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
