### PR TITLE
Transform non-TextXErrors from object processors to TextXErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ please take a look at related PRs and issues and see if the change affects you.
 
 - Added ability to access the full path of named objects
   traversed while resolving a RREL expression ([#304]).
+- Added decorator `textx.textxerror_wrap` for object processors 
+  to automatically transform non-TextXErrors to TextXErrors
+  in order to indicate the filename and position of the
+  element being processed ([#306]).
 
 ### Fixed
 
@@ -521,6 +525,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Export to dot.
 
 
+[#306]: https://github.com/textX/textX/pull/306
 [#304]: https://github.com/textX/textX/pull/304
 [#301]: https://github.com/textX/textX/issues/301
 [#299]: https://github.com/textX/textX/pull/299

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -210,6 +210,13 @@ on-the-fly model interpretation. For more information
 !!! note
     For more information please take a look at [the tests](https://github.com/textX/textX/blob/master/tests/functional/test_processors.py).
 
+Object processors decorated with `textx.textxerror_wrap` will transform
+any exceptions not derived from `TextXError` to a `TextXError` (including
+line/column and filename information). This can be useful, if
+object processors transform values using non-textx libraries (like `datetime`)
+and you wish to get the location in the model file, where errors occur
+while transforming the data (see 
+[these tests](https://github.com/textX/textX/blob/master/tests/functional/test_processors.py)).
 
 ## Built-in objects
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ packages = textx, textx.scoping, textx.cli
 zip_safe = False
 install_requires =
     Arpeggio >= 1.9.0
+    future
 include_package_data = True
 package_dir =
     textx = textx

--- a/tests/functional/test_user_classes.py
+++ b/tests/functional/test_user_classes.py
@@ -95,10 +95,17 @@ def test_user_class_with_imported_grammar():
     this_folder = dirname(abspath(__file__))
     mm = metamodel_from_file(join(this_folder, "user_classes", "B.tx"),
                              classes=[AThing, BThing])
+    called = [False]
+
+    def dummy(_):
+        called[0] = True
+
+    mm.register_obj_processors({'AThing': dummy})
     m = mm.model_from_str("""
         A 2,1
         B Hello
     """)
+    assert called[0]
     assert m.a.v.x == 2
     assert m.a.v.y == 1
     assert m.b.v.name == "Hello"

--- a/textx/__init__.py
+++ b/textx/__init__.py
@@ -1,7 +1,8 @@
 # flake8: noqa
 from textx.metamodel import metamodel_from_file, metamodel_from_str
 from textx.model import get_children_of_type, get_parent_of_type, \
-    get_model, get_metamodel, get_children, get_location, textx_isinstance
+    get_model, get_metamodel, get_children, get_location, textx_isinstance, \
+    textxerror_wrap
 from textx.exceptions import TextXError, TextXSyntaxError, \
     TextXSemanticError, TextXRegistrationError
 from textx.registration import (LanguageDesc, GeneratorDesc,


### PR DESCRIPTION
Use case: Exceptions from objects processors shall always be TextXErrors, to indicate filename and error location.
```
 grammar = r"""
        Model: date=Date;
        Date: d=INT '.' m=INT '.' y=INT;
        """

    mm = metamodel_from_str(grammar)
    from datetime import datetime
    mm.register_obj_processors({'Date': lambda x: datetime(day=x.d, month=x.m, year=x.y)})
```

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [x] Squash commit messages and separate changes from tests/functional/test_user_classes.py ("enhancement of the existing test") 
- [X] Tests have been included and/or updated
- [X] Docstrings have been included and/or updated, as appropriate
- [x] Standalone docs have been updated accordingly
- [x] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
