### PR TITLE
Improve rendering of PlantUML references

### DIFF
--- a/textx/export.py
+++ b/textx/export.py
@@ -250,15 +250,14 @@ set namespaceSeparator .
             # If attribute is a reference
             # mult = attr.mult if not attr.mult == MULT_ONE else ""
             if attr.cont:
-                arr = "*--"
+                arr = "*-->"
             else:
-                arr = "o--"
-            if attr.mult == MULT_ZEROORMORE:
-                arr = arr + ' "0..*"'
-            elif attr.mult == MULT_ONEORMORE:
-                arr = arr + ' "1..*"'
-            return '{} {} {}\n'.format(
-                cls._tx_fqn, arr, attr.cls._tx_fqn)
+                arr = "o-->"
+            name = attr.name
+            if attr.mult != "1":
+                name += " " + attr.mult
+            return '{} {} {}: {}\n'.format(
+                cls._tx_fqn, arr, attr.cls._tx_fqn, name)
 
     def render_inherited_by(self, base, special):
         return '{} <|-- {}\n'.format(base._tx_fqn, special._tx_fqn)


### PR DESCRIPTION
This is a smaller rework of rendering of PlantUML references.

- All references are named and directed
- All cardinalities, except "1" are rendered also
- Labels are put in the middle of the link as I had overlapping issues when  they are located at the end of the links.

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
