### PR TITLE
Fix/improve error messages

### DIFF
--- a/.github/workflows/ci-linux-ubuntu.yml
+++ b/.github/workflows/ci-linux-ubuntu.yml
@@ -23,6 +23,7 @@ jobs:
       run: |
         cd ..
         git clone --depth=1 --branch=master git://github.com/textX/Arpeggio.git
+        pip uninstall -y Arpeggio
         cd Arpeggio && python setup.py install
         cd ../textX
     - name: Run unit tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Fixed
 
+- Fix exception/error messages ([#320])
 - Relaxed assert in model creation enabling some model changes in user classes
   ([#311])
 - Fixed model export to dot in cases where textX object is replaced in the
@@ -37,6 +38,15 @@ please take a look at related PRs and issues and see if the change affects you.
 - Migrated from Travis CI to GitHub Actions ([#307])
 - Dropped support for deprecated Python versions. The lowest supported version
   is 3.6. **(BIC)**
+
+[#320]: https://github.com/textX/textX/pull/320
+[#313]: https://github.com/textX/textX/pull/313
+[#311]: https://github.com/textX/textX/pull/311
+[#307]: https://github.com/textX/textX/issues/307
+[#306]: https://github.com/textX/textX/pull/306
+[#304]: https://github.com/textX/textX/pull/304
+[#301]: https://github.com/textX/textX/issues/301
+[#277]: https://github.com/textX/textX/issues/277
 
 
 ## [2.3.0] (released: 2020-11-01)
@@ -531,13 +541,6 @@ please take a look at related PRs and issues and see if the change affects you.
   - Metamodel and model construction.
   - Export to dot.
 
-[#277]: https://github.com/textX/textX/issues/277
-[#313]: https://github.com/textX/textX/pull/313
-[#311]: https://github.com/textX/textX/pull/311
-[#307]: https://github.com/textX/textX/issues/307
-[#306]: https://github.com/textX/textX/pull/306
-[#304]: https://github.com/textX/textX/pull/304
-[#301]: https://github.com/textX/textX/issues/301
 [#299]: https://github.com/textX/textX/pull/299
 [#298]: https://github.com/textX/textX/pull/298
 [#294]: https://github.com/textX/textX/pull/294

--- a/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_issue196.py
@@ -68,7 +68,7 @@ def test_issue196_syntax_error_1():
         metamodel_for_language('flow-dsl')._tx_model_repository.all_models)
 
     with pytest.raises(TextXError,
-                       match=r'.*error: Expected.*'):
+                       match=r'.*\d+: Expected.*'):
         mmF.model_from_file(
             os.path.join(current_dir,
                          'models',
@@ -94,7 +94,7 @@ def test_issue196_syntax_error_2():
         metamodel_for_language('flow-dsl')._tx_model_repository.all_models)
 
     with pytest.raises(TextXError,
-                       match=r'.*error: Expected.*'):
+                       match=r'.*\d+: Expected.*'):
         mmF.model_from_file(os.path.join(current_dir,
                                          'models',
                                          'MODEL_WITH_SYNTAX_ERROR.eflow'))

--- a/tests/functional/registration/test_check.py
+++ b/tests/functional/registration/test_check.py
@@ -17,7 +17,7 @@ def test_object_processor_with_optional_parameter_default():
     model_file = os.path.join(this_folder,
                               'projects', 'types_dsl', 'tests',
                               'models', 'types_with_error.etype')
-    with raises(TextXSyntaxError, match='error: types must be lowercase'):
+    with raises(TextXSyntaxError, match='types must be lowercase'):
         mm.model_from_file(model_file)
 
 
@@ -26,7 +26,7 @@ def test_object_processor_with_optional_parameter_on():
     model_file = os.path.join(this_folder,
                               'projects', 'types_dsl', 'tests',
                               'models', 'types_with_error.etype')
-    with raises(TextXSyntaxError, match='error: types must be lowercase'):
+    with raises(TextXSyntaxError, match='types must be lowercase'):
         mm.model_from_file(model_file, type_name_check='on')
 
 
@@ -102,7 +102,8 @@ def test_check_invalid_model():
     runner = CliRunner()
     result = runner.invoke(textx, ['check', model_file])
     assert result.exit_code != 0
-    assert 'error: types must be lowercase' in result.output
+    assert 'Error:' in result.output
+    assert 'types must be lowercase' in result.output
 
 
 def test_check_invalid_language():

--- a/tests/functional/regressions/test_issue188.py
+++ b/tests/functional/regressions/test_issue188.py
@@ -39,6 +39,6 @@ def test_issue188_skipws_5():
         SPACE[noskipws]: ' ';
     ''')
     with pytest.raises(TextXSyntaxError,
-                       match='.*Expected \'bar \' at position'):
+                       match=r'.*\d+: Expected \'bar \''):
         mm.model_from_str(' foo bar')
     mm.model_from_str(' foo bar ')

--- a/tests/functional/test_scoping/test_full_qualified_name.py
+++ b/tests/functional/test_scoping/test_full_qualified_name.py
@@ -103,7 +103,7 @@ def test_fully_qualified_name_ref():
     # MODEL WITH ERROR
     ############################
     with raises(textx.exceptions.TextXSemanticError,
-                match=r'None:8:.*: error.*Unknown object.*Part1.*'):
+                match=r'None:8:.*: Unknown object.*Part1.*'):
         my_metamodel.model_from_str(''' #1
         package P1 { #2
             class Part1 { #3
@@ -118,7 +118,7 @@ def test_fully_qualified_name_ref():
 
     with raises(textx.exceptions.TextXSemanticError,
                 match=r'.*test_fully_qualified_name_test_error.model:8:\d+:'
-                      ' error.*Unknown object.*Part1.*'):
+                      ' Unknown object.*Part1.*'):
         my_metamodel.model_from_file(
             join(dirname(__file__),
                  "misc", "test_fully_qualified_name_test_error.model"))

--- a/tests/functional/test_scoping/test_full_qualified_name_rrel_manual.py
+++ b/tests/functional/test_scoping/test_full_qualified_name_rrel_manual.py
@@ -102,7 +102,7 @@ def test_fully_qualified_name_ref():
     # MODEL WITH ERROR
     ############################
     with raises(textx.exceptions.TextXSemanticError,
-                match=r'None:8:.*: error.*Unknown object.*Part1.*'):
+                match=r'None:8:.*: Unknown object.*Part1.*'):
         my_metamodel.model_from_str(''' #1
         package P1 { #2
             class Part1 { #3
@@ -117,7 +117,7 @@ def test_fully_qualified_name_ref():
 
     with raises(textx.exceptions.TextXSemanticError,
                 match=r'.*test_fully_qualified_name_test_error.model:8:\d+:'
-                      ' error.*Unknown object.*Part1.*'):
+                      ' Unknown object.*Part1.*'):
         my_metamodel.model_from_file(
             join(dirname(__file__),
                  "misc", "test_fully_qualified_name_test_error.model"))

--- a/tests/functional/test_scoping/test_plain_name.py
+++ b/tests/functional/test_scoping/test_plain_name.py
@@ -222,7 +222,7 @@ def test_plain_name_ref_with_muli_metamodel_support():
     # MODEL WITH ERROR (double entries)
     ############################
     with raises(textx.exceptions.TextXSemanticError,
-                match=r'.*None:10:\d+: error: name Part1 is not unique.*'):
+                match=r'.*None:10:\d+: name Part1 is not unique.*'):
         my_metamodel.model_from_str('''
         package P1 {
             class Part1 {

--- a/textx/exceptions.py
+++ b/textx/exceptions.py
@@ -1,21 +1,24 @@
 class TextXError(Exception):
     def __init__(self, message, line=None, col=None,
-                 err_type=None, filename=None):
+                 err_type=None, filename=None, context=None):
         super(TextXError, self).__init__(message.encode('utf-8'))
         self.line = line
         self.col = col
         self.err_type = err_type
         self.filename = filename
         self.message = message
+        self.context = context
 
     def __str__(self):
         if self.line or self.col or self.filename:
             # gcc style error format
-            return "{}:{}:{}: error: {}".format(
+            return "{}:{}:{}: {}{}".format(
                 str(self.filename),
                 str(self.line),
                 str(self.col),
-                self.message
+                self.message,
+                " => '{}'".format(self.context) if self.context else ""
+
             )
         else:
             return super(TextXError, self).__str__()
@@ -23,18 +26,18 @@ class TextXError(Exception):
 
 class TextXSemanticError(TextXError):
     def __init__(self, message, line=None, col=None, err_type=None,
-                 expected_obj_cls=None, filename=None):
+                 expected_obj_cls=None, filename=None, context=None):
         super(TextXSemanticError, self).__init__(
-            message, line, col, err_type, filename)
+            message, line, col, err_type, filename, context)
         # Expected object of class
         self.expected_obj_cls = expected_obj_cls
 
 
 class TextXSyntaxError(TextXError):
     def __init__(self, message, line=None, col=None, err_type=None,
-                 expected_rules=None, filename=None):
+                 expected_rules=None, filename=None, context=None):
         super(TextXSyntaxError, self).__init__(
-            message, line, col, err_type, filename)
+            message, line, col, err_type, filename, context)
         # Possible rules on this position
         self.expected_rules = expected_rules
 

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -882,9 +882,7 @@ class TextXVisitor(RRELVisitor):
             regex.compile()
         except Exception as e:
             line, col = self.grammar_parser.pos_to_linecol(node[1].position)
-            raise TextXSyntaxError(
-                "{} at {}"
-                .format(text(e), text((line, col))), line, col)
+            raise TextXSyntaxError(text(e), line, col)
         return regex
 
     def visit_obj_ref(self, node, children):
@@ -959,8 +957,10 @@ def language_from_str(language_def, metamodel, file_name):
     try:
         parse_tree = parser.parse(language_def, file_name)
     except NoMatch as e:
-        line, col = parser.pos_to_linecol(e.position)
-        raise TextXSyntaxError(text(e), line, col)
+        e.eval_attrs()
+        raise TextXSyntaxError(e.message, e.line, e.col,
+                               filename=e.parser.file_name,
+                               context=e.context)
 
     # Construct new parser and meta-model based on the given language
     # description.

--- a/textx/model.py
+++ b/textx/model.py
@@ -328,10 +328,12 @@ def get_model_parser(top_rule, comments_model, **kwargs):
             try:
                 return self.parser_model.parse(self)
             except NoMatch as e:
-                line, col = e.parser.pos_to_linecol(e.position)
-                raise TextXSyntaxError(message=text(e),
-                                       line=line,
-                                       col=col,
+                e.eval_attrs()
+                raise TextXSyntaxError(message=e.message,
+                                       line=e.line,
+                                       col=e.col,
+                                       filename=e.parser.file_name,
+                                       context=e.context,
                                        expected_rules=e.rules)
 
         def get_model_from_file(self, file_name, encoding, debug,


### PR DESCRIPTION
I noticed that we have a problem with error messages returned when e.g. running the textx command. The problem was that when syntax error is encountered Arpeggio will return the exception where the location and the context is already baked into the exception string which made textX messages redundant.

E.g. previously we had:

```
(venv) ~/repos/textX/textX/examples/robot ±master⚡ » textx generate --grammar robot.tx program.rbt --target dot
   --overwrite
Generating dot target from models:
/home/igor/repos/textX/textX/examples/robot/program.rbt
Error: None:3:3: error: Expected 'initial' or 'up' or 'down' or 'left' or 'right' or 'end' at position
 /home/igor/repos/textX/textX/examples/robot/program.rbt:(3, 3) => 'al 3, 1   *north 4   '.

```
Notice that we have word `error`, filename and location printed twice. The filename is even wrong at the first occurrence (`None`).

This PR aims to fix this. But it required fix in the Arpeggio also. See the branch `nomatch-eval-attrs` in the Arpeggio repo.

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
