### PR TITLE
Bugfix/do not allow empty rrel expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,7 @@ venv
 .pytest_cache
 .idea
 examples/render_all_grammars/pu
+tests/functional/test_metamodel/model_param_generate_test.testtarget
+
 examples/render_all_grammars/REPORT.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,6 @@ venv
 .pytest_cache
 .idea
 examples/render_all_grammars/pu
-tests/functional/test_metamodel/model_param_generate_test.testtarget
-
 examples/render_all_grammars/REPORT.md
+tests/functional/test_metamodel/model_param_generate_test.testtarget
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ please take a look at related PRs and issues and see if the change affects you.
   ([#311])
 - Fixed model export to dot in cases where textX object is replaced in the
   processor([#301])
+- Do not allow "empty" RREL expressions (compare unittests in `test_rrel.py`; [#355])
 
 ### Changed
 
@@ -545,6 +546,7 @@ please take a look at related PRs and issues and see if the change affects you.
   - Metamodel and model construction.
   - Export to dot.
 
+[#355]: https://github.com/textX/textX/pull/355
 [#299]: https://github.com/textX/textX/pull/299
 [#298]: https://github.com/textX/textX/pull/298
 [#294]: https://github.com/textX/textX/pull/294

--- a/tests/functional/test_scoping/test_rrel.py
+++ b/tests/functional/test_scoping/test_rrel.py
@@ -172,6 +172,9 @@ def test_rrel_basic_lookup():
     none = find(my_model, "", "..")
     assert none is None
 
+    m = find(my_model, "", ".")  # '.' references the current element
+    assert m is my_model
+
     inner = find(my_model, "inner", "~packages.~packages.~classes.attributes")
     assert inner.name == "inner"
 

--- a/tests/functional/test_scoping/test_rrel.py
+++ b/tests/functional/test_scoping/test_rrel.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from textx.scoping.rrel import rrel_standalone, parse
-from arpeggio import ParserPython
+from arpeggio import ParserPython, NoMatch
 from textx import metamodel_from_str, textx_isinstance
 from textx.scoping.rrel import find, find_object_with_path
 from pytest import raises
@@ -40,9 +40,9 @@ def test_rrel_basic_parser2():
     assert str(tree) == 'parent(NAME)'
 
     # do not allow "empty" rrel expressions:
-    with raises(Exception):
+    with raises(NoMatch):
         tree = parse("")
-    with raises(Exception):
+    with raises(NoMatch):
         tree = parse("a,b,c,")
 
 

--- a/tests/functional/test_scoping/test_rrel.py
+++ b/tests/functional/test_scoping/test_rrel.py
@@ -34,8 +34,16 @@ def test_rrel_basic_parser2():
     assert str(tree) == 'instance.(type.vals)*'
     tree = parse("a,b,c")
     assert str(tree) == 'a,b,c'
+    tree = parse("a.b.c")
+    assert str(tree) == 'a.b.c'
     tree = parse("parent(NAME)")
     assert str(tree) == 'parent(NAME)'
+
+    # do not allow "empty" rrel expressions:
+    with raises(Exception):
+        tree = parse("")
+    with raises(Exception):
+        tree = parse("a,b,c,")
 
 
 metamodel_str = '''

--- a/textx/scoping/rrel.py
+++ b/textx/scoping/rrel.py
@@ -35,9 +35,10 @@ def rrel_zero_or_more():
 
 
 def rrel_path():
-    return Optional(['^', rrel_dots]), ArpeggioZeroOrMore(
-        [rrel_zero_or_more, rrel_path_element], '.'), Optional(
-        [rrel_zero_or_more, rrel_path_element])
+    return [(Optional(['^', rrel_dots]),
+            ArpeggioZeroOrMore([rrel_zero_or_more, rrel_path_element],'.'),
+             [rrel_zero_or_more, rrel_path_element]),
+            ['^', rrel_dots]]
 
 
 def rrel_sequence():

--- a/textx/scoping/rrel.py
+++ b/textx/scoping/rrel.py
@@ -36,7 +36,7 @@ def rrel_zero_or_more():
 
 def rrel_path():
     return [(Optional(['^', rrel_dots]),
-            ArpeggioZeroOrMore([rrel_zero_or_more, rrel_path_element],'.'),
+            ArpeggioZeroOrMore([rrel_zero_or_more, rrel_path_element], '.'),
              [rrel_zero_or_more, rrel_path_element]),
             ['^', rrel_dots]]
 

--- a/textx/textx.tx
+++ b/textx/textx.tx
@@ -135,7 +135,7 @@ ClassName:
 // RREL
 RRELExpression: multi?="+m:" sequence=RRELSequence;
 RRELSequence: paths+=RRELPath[','];
-RRELPath: (up='^' | dots=RRELDots)? parts*=RRELPathPart['.'];
+RRELPath: ((up='^' | dots=RRELDots)? parts+=RRELPathPart['.']) | (up='^' | dots=RRELDots);
 RRELPathPart: RRELZeroOrMore | RRELPathElement;
 RRELZeroOrMore: element=RRELPathElement '*';
 RRELPathElement: RRELParent | RRELBrackets | RRELNavigation;


### PR DESCRIPTION
@igordejanovic Please take a look once you find time (no hurry). This is a minor change (in my eyes):
 * It was possible to use empty rrel expressions. This was changed (disallowed).
 * Added unittests
 * To reference the current element you must instead use '.' (added example in unittests)


<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [X] Commit messages are meaningful (see [this][commit messages] for details)
- [X] Tests have been included and/or updated
- [n/a] Docstrings have been included and/or updated, as appropriate
- [n/a] Standalone docs have been updated accordingly
- [n/a] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).

[commit messages]: https://chris.beams.io/posts/git-commit/
