### PR TITLE
Feature/additional metamodel tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,14 @@ please take a look at related PRs and issues and see if the change affects you.
 
 ### Changed
 
+- Inheritance chain calculation. Possible **(BIC)** ([#369]).
 - Added `def_file_name` attribute to `RefRulePosition` for storing the definition's
   model file name in case of cross-references between models. ([#313],[#277])
 - Migrated from Travis CI to GitHub Actions ([#307])
 - Dropped support for deprecated Python versions. The lowest supported version
   is 3.6. **(BIC)**
 
+[#369]: https://github.com/textX/textX/pull/369
 [#360]: https://github.com/textX/textX/issues/360
 [#323]: https://github.com/textX/textX/issues/323
 [#320]: https://github.com/textX/textX/pull/320

--- a/tests/functional/test_metamodel_properties.py
+++ b/tests/functional/test_metamodel_properties.py
@@ -1,0 +1,94 @@
+from __future__ import unicode_literals
+import textx
+
+
+def test_metamodel_rule_properties():
+    mm = textx.metamodel_from_str(r'''
+        Model: 'value' a=C b=K c=N d=O e=P q=Q l=L;
+        C: D|E;
+        D: 'D';
+        E: F;
+        F: 'F';
+        K: L|M;
+        L: 'L' name=ID;
+        M: 'M' name=ID;
+        N: L|M|E;
+        O: L|M|'test';
+        P: '1'|'2'|'3';
+        Q: '1'|'2'|'3' L;
+        R: E L;
+        S: E L | M;
+        T: M;
+    ''')
+    assert mm is not None
+    all_rules = mm._current_namespace
+    assert all_rules['C']._tx_type == 'match'
+    assert all_rules['D']._tx_type == 'match'
+    assert all_rules['E']._tx_type == 'match'
+    assert all_rules['F']._tx_type == 'match'
+    assert all_rules['K']._tx_type == 'abstract'
+    assert all_rules['L']._tx_type == 'common'
+    assert all_rules['M']._tx_type == 'common'
+    assert all_rules['N']._tx_type == 'abstract'
+    assert all_rules['O']._tx_type == 'abstract'
+    assert all_rules['P']._tx_type == 'match'
+    assert all_rules['Q']._tx_type == 'abstract'
+    assert all_rules['R']._tx_type == 'abstract'
+    assert all_rules['S']._tx_type == 'abstract'
+    assert all_rules['T']._tx_type == 'abstract'
+
+
+def test_metamodel_abstract_rule_detail1():
+    mm = textx.metamodel_from_str(r'''
+        Model: 'value' a=C b=K c=N d=O e=P q=Q l=L;
+        C: D|E;
+        D: 'D';
+        E: F;
+        F: 'F';
+        K: L|M;
+        L: 'L' name=ID;
+        M: 'M' name=ID;
+        N: L|M|E;
+        O: L|M|'test';
+        P: '1'|'2'|'3';
+        Q: '1'|'2'|'3' L;
+        R: E L;
+        S: E L | M;
+    ''')
+    assert mm is not None
+    all_rules = mm._current_namespace
+    assert all_rules['C']._tx_type == 'match'
+    assert all_rules['D']._tx_type == 'match'
+    assert all_rules['E']._tx_type == 'match'
+    assert all_rules['F']._tx_type == 'match'
+    assert all_rules['K']._tx_type == 'abstract'
+    assert all_rules['L']._tx_type == 'common'
+    assert all_rules['M']._tx_type == 'common'
+    assert all_rules['N']._tx_type == 'abstract'
+    assert all_rules['O']._tx_type == 'abstract'
+    assert all_rules['P']._tx_type == 'match'
+    assert all_rules['Q']._tx_type == 'abstract'
+    assert all_rules['R']._tx_type == 'abstract'
+    assert all_rules['S']._tx_type == 'abstract'
+
+
+def test_metamodel_abstract_rule_detail2():
+    # Example with "Base: Special1| (Special2 NotSpecial3)"
+    # "If there are multiple common rules than the first will be used as a result and
+    # the rest only for parsing" from http://textx.github.io/textX/stable/grammar/
+    mm = textx.metamodel_from_str(r'''
+        Model: 'value' x=Base;
+        Base: S1|(S2 NotS3); // only use first rule (S2) as
+                             // possible instance for each choice-option
+        S1: name=ID;
+        S2: name=ID;
+        NotS3: name=ID;
+    ''')
+    assert mm is not None
+    all_rules = mm._current_namespace
+    assert all_rules['Base']._tx_type == 'abstract'
+    assert textx.textx_isinstance(mm["S1"], mm["Base"])
+    assert textx.textx_isinstance(mm["S2"], mm["Base"])
+    assert not textx.textx_isinstance(mm["NotS3"], mm["Base"])  # problem
+    # problem (hint for root cause, NotS3 is part of tx_inh_by):
+    assert len(all_rules['Base']._tx_inh_by) == 2

--- a/tests/functional/test_metamodel_properties.py
+++ b/tests/functional/test_metamodel_properties.py
@@ -78,11 +78,16 @@ def test_metamodel_abstract_rule_detail2():
     # the rest only for parsing" from http://textx.github.io/textX/stable/grammar/
     mm = textx.metamodel_from_str(r'''
         Model: 'value' x=Base;
-        Base: S1|(S2 NotS3); // only use first rule (S2) as
-                             // possible instance for each choice-option
+        Base: S1 | S2 NotS3 // only use first rule (S2) as
+                            // possible instance for each choice-option
+            | (S4 | S5) S6; // Both S4 and S5 should be inheriting classes
+                            // but not S6 as it comes second in sequence.
         S1: name=ID;
         S2: name=ID;
         NotS3: name=ID;
+        S4: name=ID;
+        S5: name=ID;
+        S6: name=ID;
     ''')
     assert mm is not None
     all_rules = mm._current_namespace
@@ -90,5 +95,6 @@ def test_metamodel_abstract_rule_detail2():
     assert textx.textx_isinstance(mm["S1"], mm["Base"])
     assert textx.textx_isinstance(mm["S2"], mm["Base"])
     assert not textx.textx_isinstance(mm["NotS3"], mm["Base"])  # problem
-    # problem (hint for root cause, NotS3 is part of tx_inh_by):
-    assert len(all_rules['Base']._tx_inh_by) == 2
+
+    assert set([c.__name__ for c in all_rules['Base']._tx_inh_by]) \
+        == set(['S1', 'S2', 'S4', 'S5'])

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -373,9 +373,13 @@ class TextXVisitor(RRELVisitor):
                                 if rule._tx_class._tx_type != RULE_MATCH and\
                                         rule._tx_class not in inh_by:
                                     inh_by.append(rule._tx_class)
+                                    # stop after first added/found type
+                                    return True
                         else:
                             for r in rule.nodes:
-                                _add_reffered_classes(r, inh_by)
+                                if _add_reffered_classes(r, inh_by):
+                                    return True
+                        return False
 
                     if type(rule) is OrderedChoice:
                         for r in rule.nodes:

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -368,24 +368,26 @@ class TextXVisitor(RRELVisitor):
                     # Recursively append all referenced classes.
                     def _add_reffered_classes(rule, inh_by, start=False):
                         if rule.root and not start:
-                            if hasattr(rule, '_tx_class'):
-                                _determine_rule_type(rule._tx_class)
-                                if rule._tx_class._tx_type != RULE_MATCH and\
-                                        rule._tx_class not in inh_by:
-                                    inh_by.append(rule._tx_class)
-                                    # stop after first added/found type
-                                    return True
+                            _determine_rule_type(rule._tx_class)
+                            if rule._tx_class._tx_type != RULE_MATCH and\
+                                    rule._tx_class not in inh_by:
+                                inh_by.append(rule._tx_class)
+                                # stop after first added/found type
+                                return True
                         else:
+                            is_ordered_choice = type(rule) is OrderedChoice
+                            inh_added = False
                             for r in rule.nodes:
-                                if _add_reffered_classes(r, inh_by):
-                                    return True
+                                inh_added |= _add_reffered_classes(r, inh_by)
+                                if inh_added and not is_ordered_choice:
+                                    # If not ordered choice we should get out
+                                    # early as the rest of the rule shouldn't
+                                    # influence the inheritance hierarchy.
+                                    break
+                            return inh_added
                         return False
 
-                    if type(rule) is OrderedChoice:
-                        for r in rule.nodes:
-                            _add_reffered_classes(r, cls._tx_inh_by)
-                    else:
-                        _add_reffered_classes(rule, cls._tx_inh_by, start=True)
+                    _add_reffered_classes(rule, cls._tx_inh_by, start=True)
 
         # Multi-pass rule type resolving to support circular rule references.
         # `has_change` is a list to support outer scope variable change in


### PR DESCRIPTION
<!-- Please don't remove/change code review checklist -->
See #366: I identified an issue with the meta model not indicating the correct inherited-by information.
I debugged the code and matched it with my understanding of the textx-grammar. 
 * I found that there was no mimic of stopping after the first non-match-rule (as described in https://textx.github.io/textX/stable/grammar/: "If there are multiple common rules than the first will be used as a result and the rest only for parsing") 
 * Based on the insights i added a simple fix by stopping the insertion process in `lang.py`.

This solution is quite simple. We should have a deep look, @igordejanovic. In case of doubts I could add more "negative tests" if we sketch them in this discussion... 
 
## Code review checklist

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [n/a] Commit messages are meaningful (see [this][commit messages] for details) - summary comment will be generated
- [X] Tests have been included and/or updated
- [n/a] Docstrings have been included and/or updated, as appropriate
- [X] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
