### PR TITLE
Change obj rule ref separator to ':'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ please take a look at related PRs and issues and see if the change affects you.
 - Fixed RREL lookup in case of multi-meta models (some special cases were not
   handled correctly; [#379]).
 
+### Changed
+
+- Changed separator in obj. rule refs from `|` to `:`. Old separator
+  will still be allowed until version 4.0. ([#385], [#384])
+
+[#385]: https://github.com/textX/textX/pull/385
+[#384]: https://github.com/textX/textX/issues/384
 [#379]: https://github.com/textX/textX/pull/379
 
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -513,7 +513,7 @@ assignments. There are two types of rule references:
     that, you can use the following syntax:
 
         ScreenInstance:
-          'screen' type=[ScreenType|WORD]
+          'screen' type=[ScreenType:WORD]
         ;
 
     Here, instead of `ID` a `WORD` rule is used to match the object's identifier.

--- a/docs/multimetamodel.md
+++ b/docs/multimetamodel.md
@@ -251,7 +251,7 @@ Model:
 ;
 
 User:
-    "user" name=ID "uses" instance=[Instance|FQN] // Instance, FQN from other grammar
+    "user" name=ID "uses" instance=[Instance:FQN] // Instance, FQN from other grammar
 ;
 
 Import: 'import' importURI=STRING;

--- a/docs/rrel.md
+++ b/docs/rrel.md
@@ -15,12 +15,13 @@ reference](grammar.md#references).
 For example:
 
 ```
-Attribute: 'attr' ref=[Class|FQN|^packages*.classes] name=ID ';';
+Attribute: 'attr' ref=[Class:FQN|^packages*.classes] name=ID ';';
 ```
 
 This grammar rule has a `ref` attribute which is a reference to the `Class`
 rule. This is a link rule reference as it is enclosed inside of square brackets.
-It consists of three parts separated by `|`. The first part defines the target
+It consists of three parts where first two parts are separated by `:` while the
+second and the third are separated by `|`. The first part defines the target
 object type or its grammar rule. The second part defines what will parser match
 at the place of the reference. It would be a fully qualified name of the target
 object (thus `FQN`). The third part of the reference is RREL expression
@@ -84,7 +85,7 @@ Reference resolving expression language (RREL) consists of several operators
     information (see [tests/test_scoping/test_rrel.py,
     test_rrel_with_fixed_string_in_navigation](https://github.com/textX/textX/blob/master/tests/functional/test_scoping/test_rrel.py)):
 
-          Using: 'using' name=ID "=" type=[Type|ID|+m:
+          Using: 'using' name=ID "=" type=[Type:ID|+m:
                 ~active_types.types,                // "regular lookup"
                 'builtin'~types_collection.types    // "default lookup" - name "builtin" 
                                                     // hard coded in grammar
@@ -143,7 +144,7 @@ following example (used in rule `Attribute` to reference a model class:
     Model:     packages*=Package;
     Package:   'package' name=ID '{' classes*=Class '}';
     Class:     'class' name=ID '{' attributes*=Attribute '}';
-    Attribute: 'attr' ref=[Class|FQN|^packages*.classes] name=ID ';';
+    Attribute: 'attr' ref=[Class:FQN|^packages*.classes] name=ID ';';
     Comment:   /#.*/;
     FQN:       ID('.'ID)*;
 
@@ -176,7 +177,7 @@ names, for which the given separator makes sense):
     Model:          packages*=Package;
     Package:        'package' name=ID '{' classes*=Class '}';
     Class:          'class' name=ID '{' attributes*=Attribute '}';
-    Attribute:      'attr' ref=[Class|FQN|^packages*.classes] name=ID ';';
+    Attribute:      'attr' ref=[Class:FQN|^packages*.classes] name=ID ';';
     Comment:        /#.*/;
     FQN[split='/']: ID('/'ID)*;  // separator split='/'
 
@@ -220,7 +221,7 @@ Val:
 Instance:
     'instance' name=ID (':' type=[Struct])?;
 Reference:
-    'reference' ref=[Val|FQN|+p:instances.~type.vals.(~type.vals)*];
+    'reference' ref=[Val:FQN|+p:instances.~type.vals.(~type.vals)*];
 FQN: ID ('.' ID)*;
 ```
 

--- a/docs/scoping.md
+++ b/docs/scoping.md
@@ -6,7 +6,7 @@
 Assume a grammar with references as in the following example (grammar snippet).
 
     MyAttribute:
-            ref=[MyInterface|FQN] name=ID ';'
+            ref=[MyInterface:FQN] name=ID ';'
     ;
 
 The scope provider is responsible for the reference resolution of such a
@@ -44,19 +44,19 @@ Example (from [tests/test_scoping/test_local_scope.py](https://github.com/textX/
 ```nohighlight
 # Grammar snippet (Components.tx)
 Component:
-    'component' name=ID ('extends' extends+=[Component|FQN][','])? '{'
+    'component' name=ID ('extends' extends+=[Component:FQN][','])? '{'
         slots*=Slot
     '}'
 ;
 Slot: SlotIn|SlotOut;
 # ...
 Instance:
-    'instance' name=ID ':' component=[Component|FQN] ;
+    'instance' name=ID ':' component=[Component:FQN] ;
 Connection:
     'connect'
-      from_inst=[Instance|ID] '.' from_port=[SlotOut|ID]
+      from_inst=[Instance:ID] '.' from_port=[SlotOut:ID]
     'to'
-      to_inst=[Instance|ID] '.' to_port=[SlotIn|ID]
+      to_inst=[Instance:ID] '.' to_port=[SlotIn:ID]
 ;
 ```
 
@@ -250,7 +250,7 @@ Entity: 'entity' name=ID '{'
               properties*=Property
         '}'
 ;
-Property: name=ID ':' type=[t.BaseType|ID|+m:types];
+Property: name=ID ':' type=[t.BaseType:ID|+m:types];
 '''
 
 # Get `types` language meta-model

--- a/examples/StateMachine/state_machine.tx
+++ b/examples/StateMachine/state_machine.tx
@@ -4,7 +4,7 @@ StateMachine:
     'end'
 
     ('resetEvents'
-        resetEvents+=[Event|SMID]
+        resetEvents+=[Event:SMID]
     'end')?
 
     'commands'
@@ -34,7 +34,7 @@ State:
 ;
 
 Transition:
-    event=[Event|SMID] '=>' to_state=[State]
+    event=[Event:SMID] '=>' to_state=[State]
 ;
 
 SMID:

--- a/examples/render_all_grammars/render_all_grammars.py
+++ b/examples/render_all_grammars/render_all_grammars.py
@@ -16,6 +16,9 @@ def main(path=None, debug=False, reportfilename=None):
     print("render_all_grammars.py - example program")
     matches = []
     for root, dirnames, filenames in os.walk(path):
+        if 'textx_textx' in root:
+            # skip semantically invalid grammars
+            continue
         for filename in fnmatch.filter(filenames, '*.tx'):
             matches.append((root, filename))
 

--- a/tests/functional/examples/test_hierarchical_data_structures_referencing_attributes.py
+++ b/tests/functional/examples/test_hierarchical_data_structures_referencing_attributes.py
@@ -173,7 +173,7 @@ def test_referencing_attributes_with_rrel_all_in_one():
         Instance:
             'instance' name=ID (':' type=[Struct])?;
         Reference:
-            'reference' ref=[Val|FQN|instances.~type.vals.(~type.vals)*];
+            'reference' ref=[Val:FQN|instances.~type.vals.(~type.vals)*];
         FQN: ID ('.' ID)*;
         ''')
     m = mm.model_from_str(model_text)
@@ -235,7 +235,7 @@ def test_referencing_attributes_with_rrel_all_in_one_splitstring():
             'instance' name=ID (':' type=[Struct])?;
         Reference:
             'reference' instance=[Instance]
-            '.' ref=[Val|FQN|.~instance.~type.vals.(~type.vals)*];
+            '.' ref=[Val:FQN|.~instance.~type.vals.(~type.vals)*];
         FQN[split='->']: ID ('->' ID)*;
         ''')
     m = mm.model_from_str('''
@@ -287,7 +287,7 @@ def test_referencing_attributes_with_rrel_and_full_path_access():
         Instance:
             'instance' name=ID (':' type=[Struct])?;
         Reference:
-            'reference' ref=[Val|FQN|+p:instances.~type.vals.(~type.vals)*];
+            'reference' ref=[Val:FQN|+p:instances.~type.vals.(~type.vals)*];
         FQN: ID ('.' ID)*;
         ''')
     m = mm.model_from_str(model_text)

--- a/tests/functional/registration/projects/data_dsl/data_dsl/Data.tx
+++ b/tests/functional/registration/projects/data_dsl/data_dsl/Data.tx
@@ -4,6 +4,6 @@ Model: includes*=Include data+=Data;
 Data: 'data' name=ID '{'
     attributes+=Attribute
 '}';
-Attribute: name=ID ':' type=[t.Type|ID|+m:types];
+Attribute: name=ID ':' type=[t.Type:ID|+m:types];
 Include: '#include' importURI=STRING;
 Comment: /\/\/.*$/;

--- a/tests/functional/registration/projects/data_dsl/tests/test_data_dsl.py
+++ b/tests/functional/registration/projects/data_dsl/tests/test_data_dsl.py
@@ -14,5 +14,5 @@ def test_data_dsl():
     model = mmD.model_from_file(os.path.join(current_dir,
                                              'models',
                                              'data_structures.edata'))
-    assert(model is not None)
-    assert(len(model.data) == 3)
+    assert model is not None
+    assert len(model.data) == 3

--- a/tests/functional/registration/projects/flow_dsl/flow_dsl/Flow.tx
+++ b/tests/functional/registration/projects/flow_dsl/flow_dsl/Flow.tx
@@ -1,11 +1,11 @@
 reference data-dsl as d
 
 // TODO: add type dependent lookup rules:
-// [d.Data|ID|+m:data]
-// [Algo|ID|+m:algos]
+// [d.Data:ID|+m:data]
+// [Algo:ID|+m:algos]
 
 Model: includes*=Include algos+=Algo flows+=Flow;
-Algo: 'algo' name=ID ':' inp=[d.Data|ID|+m:data] '->' outp=[d.Data|ID|+m:data];
-Flow: 'connect' algo1=[Algo|ID|+m:algos] '->' algo2=[Algo|ID|+m:algos] ;
+Algo: 'algo' name=ID ':' inp=[d.Data:ID|+m:data] '->' outp=[d.Data:ID|+m:data];
+Flow: 'connect' algo1=[Algo:ID|+m:algos] '->' algo2=[Algo:ID|+m:algos] ;
 Include: '#include' importURI=STRING;
 Comment: /\/\/.*$/;

--- a/tests/functional/registration/projects/flow_dsl/tests/test_flow_dsl.py
+++ b/tests/functional/registration/projects/flow_dsl/tests/test_flow_dsl.py
@@ -23,9 +23,9 @@ def test_flow_dsl(clear_all):
     model = mmF.model_from_file(os.path.join(current_dir,
                                              'models',
                                              'data_flow.eflow'))
-    assert(model is not None)
-    assert(len(model.algos) == 2)
-    assert(len(model.flows) == 1)
+    assert model is not None
+    assert len(model.algos) == 2
+    assert len(model.flows) == 1
 
 
 def test_flow_dsl_validation(clear_all):

--- a/tests/functional/registration/projects/types_dsl/tests/test_types_dsl.py
+++ b/tests/functional/registration/projects/types_dsl/tests/test_types_dsl.py
@@ -22,8 +22,8 @@ def test_types_dsl(clear_all):
     model = mmT.model_from_file(os.path.join(current_dir,
                                              'models',
                                              'types.etype'))
-    assert(model is not None)
-    assert(len(model.types) == 2)
+    assert model is not None
+    assert len(model.types) == 2
 
 
 def test_types_dsl_invalid(clear_all):

--- a/tests/functional/regressions/test_issue103_python_like_import.py
+++ b/tests/functional/regressions/test_issue103_python_like_import.py
@@ -19,7 +19,7 @@ def test_issue103_python_like_import():
                 vars*=Var
         ;
         Class: 'class' name=ID '{' '}' ';';
-        Var: 'var' name=ID '=' 'new' theclass=[Class|FQN] '(' ')';
+        Var: 'var' name=ID '=' 'new' theclass=[Class:FQN] '(' ')';
         FQN: ID+['.'];
         Import: 'import' importURI=STRING;
         Comment: /#.*$/;
@@ -67,9 +67,9 @@ def test_issue103_imported_namedspaces():
         ;
         Package: PackageDef|PackageRef;
         PackageDef: "package" name=ID "{" packages*=Package classes*=Class "}";
-        PackageRef: "using" ref=[Package|FQN] "as" name=ID;
+        PackageRef: "using" ref=[Package:FQN] "as" name=ID;
         Class: 'class' name=ID '{' '}' ';';
-        Var: 'var' name=ID '=' 'new' theclass=[Class|FQN] '(' ')';
+        Var: 'var' name=ID '=' 'new' theclass=[Class:FQN] '(' ')';
         FQN: ID+['.'];
         Import: 'import' importURI=STRING;
         Comment: /#.*$/;

--- a/tests/functional/regressions/test_issue384.py
+++ b/tests/functional/regressions/test_issue384.py
@@ -1,0 +1,87 @@
+# Test separator change in link rule references
+# https://github.com/textX/textX/issues/384
+from textx import metamodel_from_str
+
+
+def test_ref_with_separator():
+    grammar = r'''
+    Model: objs+=Obj objrefs+=[Obj:ID];
+    Obj: 'obj' name=ID;
+    '''
+    mm = metamodel_from_str(grammar)
+    model = mm.model_from_str('''
+    obj first
+    obj second
+
+    first second
+    ''')
+
+    assert len(model.objrefs) == 2
+    assert model.objrefs[0].name == 'first'
+
+
+def test_ref_with_separator_and_rrel():
+    grammar = r'''
+    Model: objs+=Obj objrefs+=[Obj:Name|referenced] referenced+=Obj;
+    Obj: 'obj' name=Name val=INT;
+    Name: !'obj' ID;
+    '''
+    mm = metamodel_from_str(grammar)
+    model = mm.model_from_str('''
+    obj first 1
+    obj second 2
+
+    first second
+
+    obj first 3
+    obj second 4
+    ''')
+
+    assert len(model.objrefs) == 2
+    assert model.objrefs[0].name == 'first' and model.objrefs[0].val == 3
+
+
+def test_ref_with_separator_backward():
+    """
+    Same as above but with "|" as separator.
+    TODO: Remove in version 4.0.
+    """
+    grammar = r'''
+    Model: objs+=Obj objrefs+=[Obj|ID];
+    Obj: 'obj' name=ID;
+    '''
+    mm = metamodel_from_str(grammar)
+    model = mm.model_from_str('''
+    obj first
+    obj second
+
+    first second
+    ''')
+
+    assert len(model.objrefs) == 2
+    assert model.objrefs[0].name == 'first'
+
+
+def test_ref_with_separator_and_rrel_backward():
+    """
+    Same as above but with "|" as separator.
+    TODO: Remove in version 4.0.
+    """
+    grammar = r'''
+    Model: objs+=Obj objrefs+=[Obj|Name|referenced] referenced+=Obj;
+    Obj: 'obj' name=Name val=INT;
+    Name: !'obj' ID;
+    '''
+    mm = metamodel_from_str(grammar)
+    model = mm.model_from_str('''
+    obj first 1
+    obj second 2
+
+    first second
+
+    obj first 3
+    obj second 4
+    ''')
+
+    assert len(model.objrefs) == 2
+    assert model.objrefs[0].name == 'first' and model.objrefs[0].val == 3

--- a/tests/functional/regressions/test_issue_34_resolving.py
+++ b/tests/functional/regressions/test_issue_34_resolving.py
@@ -31,7 +31,7 @@ def test_issue_34_resolving():
     ;
 
     Cond:
-        attribute = [Attribute|attr_id] '<' values=STRING
+        attribute = [Attribute:attr_id] '<' values=STRING
     ;
 
     attr_id:

--- a/tests/functional/test_objcrossref_positions.py
+++ b/tests/functional/test_objcrossref_positions.py
@@ -14,7 +14,7 @@ Package:
         '}'
 ;
 Object:
-    'object' name=ID ('ref' ref=[Object|FQN])?
+    'object' name=ID ('ref' ref=[Object:FQN])?
 ;
 FQN: ID+['.'];
 FQNI: ID+['.']('.*')?;

--- a/tests/functional/test_scoping/components_model1/Components.tx
+++ b/tests/functional/test_scoping/components_model1/Components.tx
@@ -23,7 +23,7 @@ Interface: 'interface' name=ID;
 // A component defines something with in/out ports
 // A component can inherit form another component --> lookup with inheritance
 Component:
-    'component' name=ID ('extends' extends+=[Component|FQN][','])? '{'
+    'component' name=ID ('extends' extends+=[Component:FQN][','])? '{'
         slots*=Slot
     '}'
 ;
@@ -32,26 +32,26 @@ Slot: SlotIn|SlotOut;
 
 SlotIn:
     'in' name=ID
-    ('(' 'format' formats+=[Interface|FQN][','] ')')?
+    ('(' 'format' formats+=[Interface:FQN][','] ')')?
 ;
 SlotOut:
     'out' name=ID
-    ('(' 'format' formats+=[Interface|FQN][','] ')')?
+    ('(' 'format' formats+=[Interface:FQN][','] ')')?
 ;
 
 // An instance of a component can be connected to other instances
 // always with portout --> portin
 Instance:
-    'instance' name=ID ':' component=[Component|FQN] ;
+    'instance' name=ID ':' component=[Component:FQN] ;
 
 // A connection connects two instances
 // --> lookup of ports to corresponding component belonging to the instance
 // --> lookup of ports with inheritance
 Connection:
     'connect'
-      from_inst=[Instance|ID] '.' from_port=[SlotOut|ID]
+      from_inst=[Instance:ID] '.' from_port=[SlotOut:ID]
     'to'
-      to_inst=[Instance|ID] '.' to_port=[SlotIn|ID]
+      to_inst=[Instance:ID] '.' to_port=[SlotIn:ID]
 ;
 
 FQN: ID+['.'];

--- a/tests/functional/test_scoping/components_model1/ComponentsRrel.tx
+++ b/tests/functional/test_scoping/components_model1/ComponentsRrel.tx
@@ -23,7 +23,7 @@ Interface: 'interface' name=ID;
 // A component defines something with in/out ports
 // A component can inherit form another component --> lookup with inheritance
 Component:
-    'component' name=ID ('extends' extends+=[Component|FQN|^packages*.components][','])? '{'
+    'component' name=ID ('extends' extends+=[Component:FQN|^packages*.components][','])? '{'
         slots*=Slot
     '}'
 ;
@@ -32,26 +32,26 @@ Slot: SlotIn|SlotOut;
 
 SlotIn:
     'in' name=ID
-    ('(' 'format' formats+=[Interface|FQN|^packages*.interfaces][','] ')')?
+    ('(' 'format' formats+=[Interface:FQN|^packages*.interfaces][','] ')')?
 ;
 SlotOut:
     'out' name=ID
-    ('(' 'format' formats+=[Interface|FQN|^packages*.interfaces][','] ')')?
+    ('(' 'format' formats+=[Interface:FQN|^packages*.interfaces][','] ')')?
 ;
 
 // An instance of a component can be connected to other instances
 // always with portout --> portin
 Instance:
-    'instance' name=ID ':' component=[Component|FQN|^packages*.components] ;
+    'instance' name=ID ':' component=[Component:FQN|^packages*.components] ;
 
 // A connection connects two instances
 // --> lookup of ports to corresponding component belonging to the instance
 // --> lookup of ports with inheritance
 Connection:
     'connect'
-      from_inst=[Instance|ID|^instances] '.' from_port=[SlotOut|ID|.~from_inst.~component.(~extends)*.slots]
+      from_inst=[Instance:ID|^instances] '.' from_port=[SlotOut:ID|.~from_inst.~component.(~extends)*.slots]
     'to'
-      to_inst=[Instance|ID|^instances] '.' to_port=[SlotIn|ID|.~to_inst.~component.(~extends)*.slots]
+      to_inst=[Instance:ID|^instances] '.' to_port=[SlotIn:ID|.~to_inst.~component.(~extends)*.slots]
 ;
 
 FQN: ID+['.'];

--- a/tests/functional/test_scoping/components_model2/Components.tx
+++ b/tests/functional/test_scoping/components_model2/Components.tx
@@ -19,7 +19,7 @@ Package:
 // A component defines something with in/out ports
 // A component can inherit form another component --> lookup with inheritance
 Component:
-    'component' name=ID ('extends' extends=[Component|FQN])? '{'
+    'component' name=ID ('extends' extends=[Component:FQN])? '{'
         slots*=Slot
     '}'
 ;
@@ -36,7 +36,7 @@ SlotOut:
 // An instance of a component can be connected to other instances
 // always with portout --> portin
 Instance:
-    'instance' name=ID ':' component=[Component|FQN] ;
+    'instance' name=ID ':' component=[Component:FQN] ;
 
 // A connection connects two instances
 // --> lookup of ports to corresponding component belonging to the instance
@@ -44,9 +44,9 @@ Instance:
 //   resolved later...
 Connection:
     'connect'
-      from_port=[SlotOut|ID] 'from' from_inst=[Instance|ID]
+      from_port=[SlotOut:ID] 'from' from_inst=[Instance:ID]
     '->'
-      to_port=[SlotIn|ID] 'from' to_inst=[Instance|ID]
+      to_port=[SlotIn:ID] 'from' to_inst=[Instance:ID]
 ;
 
 FQN: ID+['.'];

--- a/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
+++ b/tests/functional/test_scoping/importURI_variations/test_importURI_variations.py
@@ -19,7 +19,7 @@ Package:
 ;
 
 Object:
-    'object' name=ID text=STRING ('ref' ref=[Object|FQN])? ';'?
+    'object' name=ID text=STRING ('ref' ref=[Object:FQN])? ';'?
 ;
 
 FQN: ID+['.'];

--- a/tests/functional/test_scoping/interface_model1/Interface.tx
+++ b/tests/functional/test_scoping/interface_model1/Interface.tx
@@ -28,10 +28,10 @@ Interface:
 Attribute: RawTypeAttribute|EmbeddedAttribute;
 
 RawTypeAttribute:
-        ref=[RawType|FQN] name=ID ';'
+        ref=[RawType:FQN] name=ID ';'
 ;
 EmbeddedAttribute:
-        '->' ref=[Interface|FQN] name=ID ';'
+        '->' ref=[Interface:FQN] name=ID ';'
 ;
 
 FQN: ID+['.'];

--- a/tests/functional/test_scoping/interface_model2/Interface.tx
+++ b/tests/functional/test_scoping/interface_model2/Interface.tx
@@ -27,10 +27,10 @@ Interface:
 Attribute: RawTypeAttribute|EmbeddedAttribute;
 
 RawTypeAttribute:
-        ref=[RawType|FQN] name=ID ';'
+        ref=[RawType:FQN] name=ID ';'
 ;
 EmbeddedAttribute:
-        '->' ref=[Interface|FQN] name=ID ';'
+        '->' ref=[Interface:FQN] name=ID ';'
 ;
 
 FQN: ID+['.'];

--- a/tests/functional/test_scoping/metamodel_provider/Components.tx
+++ b/tests/functional/test_scoping/metamodel_provider/Components.tx
@@ -23,7 +23,7 @@ Interface: 'interface' name=ID;
 // A component defines something with in/out ports
 // A component can inherit form another component --> lookup with inheritance
 Component:
-    'component' name=ID ('extends' extends+=[Component|FQN][','])? '{'
+    'component' name=ID ('extends' extends+=[Component:FQN][','])? '{'
         slots*=Slot
     '}'
 ;
@@ -32,26 +32,26 @@ Slot: SlotIn|SlotOut;
 
 SlotIn:
     'in' name=ID
-    ('(''''format' formats+=[Interface|FQN][','] ')')?
+    ('(''''format' formats+=[Interface:FQN][','] ')')?
 ;
 SlotOut:
     'out' name=ID
-    ('(' '''format' formats+=[Interface|FQN][','] ')')?
+    ('(' '''format' formats+=[Interface:FQN][','] ')')?
 ;
 
 // An instance of a component can be connected to other instances
 // always with portout --> portin
 Instance:
-    'instance' name=ID ':' component=[Component|FQN] ;
+    'instance' name=ID ':' component=[Component:FQN] ;
 
 // A connection connects two instances
 // --> lookup of ports to corresponding component belonging to the instance
 // --> lookup of ports with inheritance
 Connection:
     'connect'
-      from_inst=[Instance|ID] '.' from_port=[SlotOut|ID]
+      from_inst=[Instance:ID] '.' from_port=[SlotOut:ID]
     'to'
-      to_inst=[Instance|ID] '.' to_port=[SlotIn|ID]
+      to_inst=[Instance:ID] '.' to_port=[SlotIn:ID]
 ;
 
 FQN: ID+['.'];

--- a/tests/functional/test_scoping/metamodel_provider/Users.tx
+++ b/tests/functional/test_scoping/metamodel_provider/Users.tx
@@ -6,7 +6,7 @@ Model:
 ;
 
 User:
-    "user" name=ID "uses" instance=[Instance|FQN]
+    "user" name=ID "uses" instance=[Instance:FQN]
 ;
 
 Import: 'import' importURI=STRING;

--- a/tests/functional/test_scoping/metamodel_provider_utf-16-le/Components.tx
+++ b/tests/functional/test_scoping/metamodel_provider_utf-16-le/Components.tx
@@ -23,7 +23,7 @@ Interface: 'interface' name=ID;
 // A component defines something with in/out ports
 // A component can inherit form another component --> lookup with inheritance
 Component:
-    'component' name=ID ('extends' extends+=[Component|FQN][','])? '{'
+    'component' name=ID ('extends' extends+=[Component:FQN][','])? '{'
         slots*=Slot
     '}'
 ;
@@ -32,26 +32,26 @@ Slot: SlotIn|SlotOut;
 
 SlotIn:
     'in' name=ID
-    ('(''''format' formats+=[Interface|FQN][','] ')')?
+    ('(''''format' formats+=[Interface:FQN][','] ')')?
 ;
 SlotOut:
     'out' name=ID
-    ('(' '''format' formats+=[Interface|FQN][','] ')')?
+    ('(' '''format' formats+=[Interface:FQN][','] ')')?
 ;
 
 // An instance of a component can be connected to other instances
 // always with portout --> portin
 Instance:
-    'instance' name=ID ':' component=[Component|FQN] ;
+    'instance' name=ID ':' component=[Component:FQN] ;
 
 // A connection connects two instances
 // --> lookup of ports to corresponding component belonging to the instance
 // --> lookup of ports with inheritance
 Connection:
     'connect'
-      from_inst=[Instance|ID] '.' from_port=[SlotOut|ID]
+      from_inst=[Instance:ID] '.' from_port=[SlotOut:ID]
     'to'
-      to_inst=[Instance|ID] '.' to_port=[SlotIn|ID]
+      to_inst=[Instance:ID] '.' to_port=[SlotIn:ID]
 ;
 
 FQN: ID+['.'];

--- a/tests/functional/test_scoping/metamodel_provider_utf-16-le/Users.tx
+++ b/tests/functional/test_scoping/metamodel_provider_utf-16-le/Users.tx
@@ -6,7 +6,7 @@ Model:
 ;
 
 User:
-    "user" name=ID "uses" instance=[Instance|FQN]
+    "user" name=ID "uses" instance=[Instance:FQN]
 ;
 
 Import: 'import' importURI=STRING;

--- a/tests/functional/test_scoping/rrel/Grammar.tx
+++ b/tests/functional/test_scoping/rrel/Grammar.tx
@@ -1,5 +1,5 @@
 Model: includes*=Include a*=A r*=R;
 A: 'A' name=ID '{' a*=A  '}';
-R: 'R' a+=[A|FQN|+pm:a*][','];
+R: 'R' a+=[A:FQN|+pm:a*][','];
 FQN[split='::']: ID ('::' ID)*;
 Include: '#include' importURI=STRING;

--- a/tests/functional/test_scoping/rrel_multifile/Grammar.tx
+++ b/tests/functional/test_scoping/rrel_multifile/Grammar.tx
@@ -1,7 +1,7 @@
 Model: includes*=Include r*=R a*=A r*=R;
 A: 'A' name=ID '{' ( a=A | p1=P1 )* '}'; 
-R: 'R' a+=[A|FQN|+pm:a*][','];
-P1: 'P1' a+=[A|FQN|+pm:..(..)*.a*][',']; // many times ".." and 1x "A"
+R: 'R' a+=[A:FQN|+pm:a*][','];
+P1: 'P1' a+=[A:FQN|+pm:..(..)*.a*][',']; // many times ".." and 1x "A"
 FQN: ID ('.' ID)*;
 Include: '#include' importURI=STRING;
 Comment: /\/\/.*?$/;

--- a/tests/functional/test_scoping/rrel_multifile/GrammarMissingPlusM.tx
+++ b/tests/functional/test_scoping/rrel_multifile/GrammarMissingPlusM.tx
@@ -1,7 +1,7 @@
 Model: includes*=Include r*=R a*=A r*=R;
 A: 'A' name=ID '{' ( a=A | p1=P1 )* '}'; 
-R: 'R' a+=[A|FQN|+pm:a*][','];
-P1: 'P1' a+=[A|FQN|+p:..(..)*.a*][',']; // many times ".." and 1x "A"
+R: 'R' a+=[A:FQN|+pm:a*][','];
+P1: 'P1' a+=[A:FQN|+p:..(..)*.a*][',']; // many times ".." and 1x "A"
 FQN: ID ('.' ID)*;
 Include: '#include' importURI=STRING;
 Comment: /\/\/.*?$/;

--- a/tests/functional/test_scoping/test_builtin_models.py
+++ b/tests/functional/test_scoping/test_builtin_models.py
@@ -16,7 +16,7 @@ Entity: 'entity' name=ID '{'
               properties*=Property
         '}'
 ;
-Property: name=ID ':' type=[t.BaseType|ID|+m:types];
+Property: name=ID ':' type=[t.BaseType:ID|+m:types];
 '''
 
 

--- a/tests/functional/test_scoping/test_children.py
+++ b/tests/functional/test_scoping/test_children.py
@@ -25,7 +25,7 @@ Class:
 ;
 
 Attribute:
-        'attr' ref=[Class|FQN] name=ID ';'
+        'attr' ref=[Class:FQN] name=ID ';'
 ;
 
 FQN: ID('.'ID)*;

--- a/tests/functional/test_scoping/test_full_qualified_name.py
+++ b/tests/functional/test_scoping/test_full_qualified_name.py
@@ -26,7 +26,7 @@ Class:
 ;
 
 Attribute:
-        'attr' ref=[Class|FQN] name=ID ';'
+        'attr' ref=[Class:FQN] name=ID ';'
 ;
 
 Comment: /#.*/;

--- a/tests/functional/test_scoping/test_full_qualified_name_rrel_manual.py
+++ b/tests/functional/test_scoping/test_full_qualified_name_rrel_manual.py
@@ -25,7 +25,7 @@ Class:
 ;
 
 Attribute:
-        'attr' ref=[Class|FQN] name=ID ';'
+        'attr' ref=[Class:FQN] name=ID ';'
 ;
 
 Comment: /#.*/;
@@ -139,7 +139,7 @@ def test_fully_qualified_name_ref_with_splitstring():
         Model: packages*=Package;
         Package: 'package' name=ID '{' classes*=Class '}';
         Class: 'class' name=ID '{'attributes*=Attribute'}';
-        Attribute: 'attr' ref=[Class|FQN] name=ID ';';
+        Attribute: 'attr' ref=[Class:FQN] name=ID ';';
         Comment: /#.*/;
         FQN[split='/']: ID('/'ID)*;
     ''')

--- a/tests/functional/test_scoping/test_rrel.py
+++ b/tests/functional/test_scoping/test_rrel.py
@@ -319,7 +319,7 @@ def test_split_str():
     mm = metamodel_from_str('''
         Model: a+=A r+=R;
         A: 'A' name=ID '{' a*=A  '}';
-        R: 'R' a+=[A|FQN|+p:a*][','];
+        R: 'R' a+=[A:FQN|+p:a*][','];
         FQN[split='::']: ID ('::' ID)*;
     ''')
     m = mm.model_from_str('''
@@ -381,7 +381,7 @@ def test_rrel_with_fixed_string_in_navigation():
     mm = metamodel_from_str(r'''
         Model: types_collection*=TypesCollection
             ('activeTypes' '=' active_types=[TypesCollection])? usings*=Using;
-        Using: 'using' name=ID "=" type=[Type|ID|+m:
+        Using: 'using' name=ID "=" type=[Type:ID|+m:
                 ~active_types.types,             // "regular lookup"
                 'builtin'~types_collection.types // "default lookup"
                                                  // name "builtin" hard coded in grammar
@@ -440,7 +440,7 @@ def test_rrel_with_fixed_string_in_navigation_with_scalars():
     mm = metamodel_from_str(r'''
         Model: types_collection=TypesCollection // scalar here (compared to last test)
             ('activeTypes' '=' active_types=[TypesCollection])? usings*=Using;
-        Using: 'using' name=ID "=" type=[Type|ID|+m:
+        Using: 'using' name=ID "=" type=[Type:ID|+m:
                 ~active_types.types,             // "regular lookup"
                 'builtin'~types_collection.types // "default lookup"
                                                  // name "builtin" hard coded in grammar

--- a/tests/functional/test_user_classes_callable.py
+++ b/tests/functional/test_user_classes_callable.py
@@ -10,10 +10,10 @@ MyModel: 'model' name=ID
   receiver+=Receiver;
 
 Sender:
-  'outgoing' name=ID 'over' connection=[Connection|ID];
+  'outgoing' name=ID 'over' connection=[Connection:ID];
 
 Receiver:
- 'incoming' name=ID 'over' connection=[Connection|ID];
+ 'incoming' name=ID 'over' connection=[Connection:ID];
 
 Connection:
   'connection' name=ID
@@ -29,10 +29,10 @@ MyModel: 'model' name=ID
   receiver+=Receiver;
 
 Sender:
-  'outgoing' name=ID 'over' connection=[Connection|ID];
+  'outgoing' name=ID 'over' connection=[Connection:ID];
 
 Receiver:
- 'incoming' name=ID 'over' connection=[Connection|ID];
+ 'incoming' name=ID 'over' connection=[Connection:ID];
 
 // fix/works (no unused user classes):
 ConnectionHandler: Sender|Receiver;

--- a/tests/functional/textx_textx/textx_rrel_test.tx
+++ b/tests/functional/textx_textx/textx_rrel_test.tx
@@ -4,9 +4,9 @@
     properly parse RRELs.
 */
 
-Multi: ref=[Target|ID|+m:^some_rule];
-MultiParent: ref=[Target|ID|+m:parent(SomeType).some_rule];
-Parent: ref=[Target|ID|parent(SomeRule).obj.ref.~extension*.methods];
-Dots: ref=[Target|ID|(..)*.(pkg)*.cls];
-Brackets: ref=[Target|ID|obj.ref.(~extension)*.methods];
-WhiteSpace: ref=[Target|ID|obj. ref.(~extension ) *. methods];
+Multi: ref=[Target:ID|+m:^some_rule];
+MultiParent: ref=[Target:ID|+m:parent(SomeType).some_rule];
+Parent: ref=[Target:ID|parent(SomeRule).obj.ref.~extension*.methods];
+Dots: ref=[Target:ID|(..)*.(pkg)*.cls];
+Brackets: ref=[Target:ID|obj.ref.(~extension)*.methods];
+WhiteSpace: ref=[Target:ID|obj. ref.(~extension ) *. methods];

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -84,7 +84,8 @@ def assignment_rhs():       return [simple_match, reference], Optional(repeat_mo
 # References
 def reference():            return [rule_ref, obj_ref]
 def rule_ref():             return ident
-def obj_ref():              return '[', class_name, Optional('|', obj_ref_rule, Optional('|', rrel_expression)), ']'
+# TODO: Remove "|" optional sep in version 4.0.
+def obj_ref():              return '[', class_name, Optional([':', '|'], obj_ref_rule, Optional('|', rrel_expression)), ']'
 
 def rule_name():            return ident
 def obj_ref_rule():         return ident
@@ -922,9 +923,9 @@ class TextXVisitor(RRELVisitor):
                 'Primitive type instances can not be referenced at {}.'
                 .format((line, col)), line, col)
         if len(children) > 1:
-            rule_name = children[1]
-            if len(children) > 2:
-                rrel_tree = children[2]
+            rule_name = children[2]
+            if len(children) > 3:
+                rrel_tree = children[3]
         else:
             # Default rule for matching obj cross-refs
             rule_name = 'ID'

--- a/textx/scoping/rrel.py
+++ b/textx/scoping/rrel.py
@@ -314,7 +314,7 @@ class RRELZeroOrMore(RRELBase):
             path_element = RRELBrackets(RRELSequence(
                 [RRELPath([path_element])]))
         self.path_element = path_element
-        assert(isinstance(self.path_element, RRELBrackets))
+        assert isinstance(self.path_element, RRELBrackets)
 
     def start_locally(self):
         return self.path_element.start_locally()
@@ -457,7 +457,7 @@ class RRELVisitor(PTNodeVisitor):
             return RRELNavigation(children[0], True, None)
 
     def visit_rrel_brackets(self, node, children):
-        assert(len(children) == 1)  # a path
+        assert len(children) == 1  # a path
         return RRELBrackets(children[0])
 
     def visit_rrel_dots(self, node, children):
@@ -473,7 +473,7 @@ class RRELVisitor(PTNodeVisitor):
         return RRELSequence(children)
 
     def visit_rrel_path_element(self, node, children):
-        assert(len(children) == 1)
+        assert len(children) == 1
         return children[0]
 
     def visit_rrel_expression(self, node, children):

--- a/textx/textx.tx
+++ b/textx/textx.tx
@@ -123,8 +123,8 @@ BuiltinRuleRef:
     'ID' | 'BOOL' | 'INT' | 'FLOAT' | 'STRING' | 'NUMBER' | 'BASETYPE'
 ;
 
-ObjRef: // TODO: add RREL
-    '[' name=ClassName ('|' obj_ref_rule=ID ('|' rrel=RRELExpression))? ']'
+ObjRef: // TODO: Remove '|' separator in 4.0
+    '[' name=ClassName ((':' | '|') obj_ref_rule=ID ('|' rrel=RRELExpression))? ']'
 ;
 
 ClassName:


### PR DESCRIPTION
This PR changes a separator between a target type and the parse rule in obj rule refs from `|` to `:`. The change is backward compatible as `|` is still allowed. This is due for removal in version 4.0 (see TODOs).

See the discussion in #384 

## Code review checklist

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
