### PR TITLE
Use `raise_from()` from vendored `six` instead of `future`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,12 @@ please take a look at related PRs and issues and see if the change affects you.
 
 - Changed separator in obj. rule refs from `|` to `:`. Old separator
   will still be allowed until version 4.0. ([#385], [#384])
+- Removed the dependency on `future` package ([#388])
 
 [#385]: https://github.com/textX/textX/pull/385
 [#384]: https://github.com/textX/textX/issues/384
 [#379]: https://github.com/textX/textX/pull/379
+[#388]: https://github.com/textX/textX/pull/388
 
 
 ## [3.0.0] (released: 2022-03-20)

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ packages = textx, textx.scoping, textx.cli
 zip_safe = False
 install_requires =
     Arpeggio >= 2.0.0
-    future
 include_package_data = True
 package_dir =
     textx = textx

--- a/textx/model.py
+++ b/textx/model.py
@@ -5,7 +5,6 @@ Model construction from parse trees and the model API.
 import sys
 import codecs
 import traceback
-from future.utils import raise_from
 from collections import OrderedDict
 from arpeggio import Parser, Sequence, NoMatch, EOF, Terminal
 from textx.exceptions import TextXError, TextXSyntaxError, TextXSemanticError
@@ -16,6 +15,7 @@ from textx.lang import PRIMITIVE_PYTHON_TYPES
 from textx.scoping import Postponed, remove_models_from_repositories, \
     get_included_models
 from textx.scoping.providers import PlainName as DefaultScopeProvider
+from textx.six import raise_from
 
 if sys.version < '3':
     text = unicode  # noqa


### PR DESCRIPTION
Use the `raise_from()` wrapper provided by the vendored `textx.six` module instead of third-party `future`.  This avoids depending on the unmaintained `future` library.

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [x] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
