### PR TITLE
Replace obsolete `py.test` invocation with `pytest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ please take a look at related PRs and issues and see if the change affects you.
 
 - Fixed RREL lookup in case of multi-meta models (some special cases were not
   handled correctly; [#379]).
+- Fixed test suite invocation to use `pytest` over `py.test` that stopped
+  working in pytest-7.2.0. ([#389])
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Ready to contribute? Here's how to set up `textX` for local development.
     To verify that everything is setup properly run tests:
     
         $ flake8
-        $ py.test tests/functional/
+        $ pytest tests/functional/
 
 4. Create a branch for local development::
 
@@ -123,8 +123,8 @@ Ready to contribute? Here's how to set up `textX` for local development.
    tests, and have a look at the coverage:
    
         $ flake8
-        $ py.test tests/functional/
-        $ coverage run --source textx -m py.test tests/functional
+        $ pytest tests/functional/
+        $ coverage run --source textx -m pytest tests/functional
         $ coverage report
         
    You can run all this at once with provided script `runtests.sh`
@@ -161,13 +161,13 @@ Before you submit a pull request, check that it meets these guidelines:
 To run a subset of tests:
 
 ```
-$ py.test tests/functional/mytest.py
+$ pytest tests/functional/mytest.py
 ```
 
 or a single test:
 
 ```
-$ py.test tests/functional/mytest.py::some_test
+$ pytest tests/functional/mytest.py::some_test
 ```
 
 ## Credit

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Run all tests and generate coverage report
 
-coverage run --omit textx/six.py --source textx -m py.test tests/functional || exit 1
+coverage run --omit textx/six.py --source textx -m pytest tests/functional || exit 1
 coverage report --fail-under 90 || exit 1
 # Run this to generate html report
 # coverage html --directory=coverage


### PR DESCRIPTION
The `py.test` project has been renamed to `py.test` years ago, and the old `py.test` module path stopped working with pytest-7.2.0.

<!-- Please don't remove/change code review checklist -->

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [x] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
