### PR TITLE
pyproject.toml: remove the "<3.13" Python version limit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,13 @@ please take a look at related PRs and issues and see if the change affects you.
   meta-classes along the inheritance chain. See [423].
 - Documentation migrated to [mdbook](https://rust-lang.github.io/mdBook/) and
   GitHub Actions.
+- The Python version limit "<3.13" has been removed from the pyproject.toml
+  file. The library should run on all Python versions starting from 3.8. See
+  [428].
 
 [423]: https://github.com/textX/textX/issues/423
 [420]: https://github.com/textX/textX/issues/420
+[428]: https://github.com/textX/textX/issues/428
 
 
 ## [4.0.1] (released: 2023-11-12)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
-requires-python = ">=3.8, <3.13"
+requires-python = ">=3.8"
 dependencies = [
     "Arpeggio >= 2.0.0",
     "importlib-metadata; python_version < '3.10'",  # For entry_points backward compatibility


### PR DESCRIPTION
Addresses #428. I also thought it would be a good to remove the upper limit because most of the time it will just work.

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [x] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [x] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
