### PR TITLE
fix: multiplicity inference for attributes with multiple assignments

### DIFF
--- a/tests/functional/regressions/test_issue357.py
+++ b/tests/functional/regressions/test_issue357.py
@@ -1,0 +1,88 @@
+"""
+Tests for issue: https://github.com/textX/textX/issues/357
+Inconsistent multiplicity of attributes with multiple assignment.
+"""
+
+from textx import metamodel_from_str
+
+
+def test_multiplicity_with_multiple_assignments_in_ordered_choice():
+    """
+    When an attribute appears in multiple assignments in an ordered choice
+    followed by another assignment in the parent sequence, the multiplicity
+    should be "1..*".
+    Grammar: (a='a'|a='b') a='c'
+    """
+    grammar = r"""
+    Model: (a='a' | a='b') a='c' 'end';
+    """
+    mm = metamodel_from_str(grammar)
+    attr = mm["Model"]._tx_attrs["a"]
+    assert attr.mult == "1..*", (
+        f"Expected multiplicity '1..*' for attribute 'a' with multiple "
+        f"assignments across ordered choice and sequence, got '{attr.mult}'"
+    )
+
+
+def test_multiplicity_with_same_attr_in_different_oc_branches():
+    """
+    When an attribute appears in different branches of an ordered choice,
+    and also in a sequential assignment, multiplicity should be "1..*".
+    """
+    grammar = r"""
+    Model: (a='x' | a='y' | a='z') a='w' 'end';
+    """
+    mm = metamodel_from_str(grammar)
+    attr = mm["Model"]._tx_attrs["a"]
+    assert attr.mult == "1..*", (
+        f"Expected multiplicity '1..*' for attribute 'a', got '{attr.mult}'"
+    )
+
+
+def test_multiplicity_with_same_attr_only_in_oc():
+    """
+    When an attribute appears in multiple branches of an ordered choice
+    but not in the parent sequence, multiplicity should remain "1"
+    (only one branch can match).
+    """
+    grammar = r"""
+    Model: (a='x' | a='y' | a='z') 'end';
+    """
+    mm = metamodel_from_str(grammar)
+    attr = mm["Model"]._tx_attrs["a"]
+    assert attr.mult == "1", (
+        f"Expected multiplicity '1' for attribute 'a' (only in OC), "
+        f"got '{attr.mult}'"
+    )
+
+
+def test_multiplicity_with_separate_attrs_in_oc():
+    """
+    When different attributes appear in different OC branches, no
+    multiplicity change should happen.
+    """
+    grammar = r"""
+    Model: (a='x' | b='y') a='z' 'end';
+    """
+    mm = metamodel_from_str(grammar)
+    attr_a = mm["Model"]._tx_attrs["a"]
+    assert attr_a.mult == "1..*", (
+        f"Expected multiplicity '1..*' for attribute 'a' (from OC + seq), "
+        f"got '{attr_a.mult}'"
+    )
+
+
+def test_multiplicity_with_plain_sequence():
+    """
+    The existing behavior: two sequential assignments of the same attribute
+    should give multiplicity "1..*".
+    """
+    grammar = r"""
+    Model: a='x' a='y' 'end';
+    """
+    mm = metamodel_from_str(grammar)
+    attr = mm["Model"]._tx_attrs["a"]
+    assert attr.mult == "1..*", (
+        f"Expected multiplicity '1..*' for attribute 'a' with sequential "
+        f"assignments, got '{attr.mult}'"
+    )

--- a/textx/lang.py
+++ b/textx/lang.py
@@ -665,9 +665,16 @@ class TextXVisitor(RRELVisitor):
                 return
 
             if isinstance(rule, OrderedChoice):
+                # Collect all attribute names assigned in any branch
+                # and propagate them to parent scope so that if the same
+                # attribute appears in another assignment in the parent
+                # sequence, multiplicity is correctly set to 1..*.
+                all_branch_attrs = set()
                 for on in rule.nodes:
-                    oc_branch_set = set()
-                    _update_attr_multiplicities(on, oc_branch_set, mult)
+                    branch_set = set()
+                    _update_attr_multiplicities(on, branch_set, mult)
+                    all_branch_attrs.update(branch_set)
+                oc_branch_set.update(all_branch_attrs)
             else:
                 if isinstance(rule, OneOrMore):
                     mult = MULT_ONEORMORE


### PR DESCRIPTION
Fixes #357

When an attribute appears in multiple assignments in an ordered choice followed by another assignment in the parent sequence (e.g. `(a='a'|a='b') a='c'`), the multiplicity was incorrectly inferred as "1" instead of "1..*" because assignments inside ordered choice branches were not propagated back to the parent scope.

Fix: Union all branch attribute sets after processing an OrderedChoice and propagate them to the parent scope so duplicate assignment detection works across the entire sequence.