### PR TITLE
chore: loosen flit_core version constraint to allow v4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ Changelog = "https://github.com/textX/textX/blob/master/CHANGELOG.md"
 
 [build-system]
 build-backend = "flit_core.buildapi"
-requires = ["flit_core >=3.8.0,<4"]
+requires = ["flit_core >=3.8.0,<5"]
 
 [tool.flit.module]
 name = "textx"


### PR DESCRIPTION
As discussed in #441 , this PR bumps the `flit_core` upper bound constraint from `<4` to `<5` in `pyproject.toml`. 

p.s. Fixes #441 

## Code review checklist

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Commit messages are meaningful (see [this][commit messages] for details)
- [ ] Tests have been included and/or updated
- [ ] Docstrings have been included and/or updated, as appropriate
- [ ] Standalone docs have been updated accordingly
- [ ] Changelog(s) has/have been updated, as needed (see `CHANGELOG.md`, no need
      to update for typo fixes and such).


[commit messages]: https://chris.beams.io/posts/git-commit/
