### PR TITLE
fix: export falsy empty-string match models

### DIFF
--- a/tests/functional/regressions/test_export_falsy_match_model.py
+++ b/tests/functional/regressions/test_export_falsy_match_model.py
@@ -1,0 +1,25 @@
+import io
+
+from textx import metamodel_from_str
+from textx.export import model_export_to_file
+
+
+def test_export_empty_match_rule_model():
+    """Match-rule roots may be empty strings; export must not treat them as omitted."""
+    mm = metamodel_from_str('Model: "hello"?;')
+    model = mm.model_from_str("")
+    assert model == ""
+
+    out = io.StringIO()
+    model_export_to_file(out, model)
+    text = out.getvalue()
+    assert "digraph textX" in text
+
+
+def test_export_rejects_missing_model_and_repo():
+    out = io.StringIO()
+    try:
+        model_export_to_file(out, None, None)
+        assert False, "expected Exception"
+    except Exception as err:
+        assert "specify either a model or a repo" in str(err)

--- a/textx/export.py
+++ b/textx/export.py
@@ -420,9 +420,10 @@ def model_export_to_file(f, model=None, repo=None):
     Returns:
         Nothing
     """
-    if not model and not repo:
+    # Falsy match-rule models (e.g. "") are valid; only None means omitted.
+    if model is None and repo is None:
         raise Exception("specify either a model or a repo")
-    if model and repo:
+    if model is not None and repo is not None:
         raise Exception("specify either a model or a repo")
 
     processed_set = set()


### PR DESCRIPTION
model_export_to_file hits Exception when falsy empty-string match model rejected by 'if not model'. This PR fixes the regression with a focused test covering the case. ## Notes (awaiting thermo)