### PR TITLE
Only unescape the delimiting quote in a STRING

### DIFF
--- a/tests/functional/test_textx_language.py
+++ b/tests/functional/test_textx_language.py
@@ -481,7 +481,9 @@ def test_string_escaping():
     "Double quotes string", "Double quotes with 'single quotes embedded'",
     "Double quotes with \" escaped quotes",
     'Single quotes string', 'Single quotes with "double quotes embedded"',
-    'Single quotes with \' escaped single quotes'
+    'Single quotes with \' escaped single quotes',
+    "Double quotes with literal backslash \' quote",
+    'Single quotes with literal backslash \" quote'
     """
     )
 
@@ -491,6 +493,9 @@ def test_string_escaping():
     assert model.a[3] == r"Single quotes string"
     assert model.a[4] == r'Single quotes with "double quotes embedded"'
     assert model.a[5] == r"Single quotes with ' escaped single quotes"
+    # A backslash before the non-delimiting quote is literal, not an escape.
+    assert model.a[6] == r"Double quotes with literal backslash \' quote"
+    assert model.a[7] == r"Single quotes with literal backslash \" quote"
 
 
 def test_rule_call_forward_backward_reference():

--- a/textx/metamodel.py
+++ b/textx/metamodel.py
@@ -294,7 +294,14 @@ class TextXMetaModel(DebugPrinter):
             "INT": lambda x: int(x),
             "FLOAT": lambda x: float(x),
             "STRICTFLOAT": lambda x: float(x),
-            "STRING": lambda x: x[1:-1].replace(r"\"", r'"').replace(r"\'", "'"),
+            # Only the delimiting quote can be escaped inside a string (see the
+            # STRING regex): a backslash before the other quote is literal, so
+            # unescape just the delimiter to avoid deleting it.
+            "STRING": lambda x: (
+                x[1:-1].replace(r"\"", '"')
+                if x[0] == '"'
+                else x[1:-1].replace(r"\'", "'")
+            ),
         }
 
         # Registered object processors (use _default_obj_processors)


### PR DESCRIPTION
The default `STRING` base-type object processor unescapes both `\"` and `\'`
regardless of which quote delimits the string:

```python
"STRING": lambda x: x[1:-1].replace(r'\"', '"').replace(r"\'", "'"),
```

But the `STRING` match regex only treats the *delimiting* quote as escapable
(`"(\"|[^"])*"` / `'(\'|[^'])*'`). Inside a double-quoted string a backslash
before a single quote is a literal backslash, not an escape — so the processor
silently deletes it:

```python
mm = metamodel_from_str('Model: s=STRING;')
mm.model_from_str(r'''"caf\'e"''').s   # -> 'cafe'   (the \ is dropped; expected: r"caf\'e")
mm.model_from_str(r"""'a\"b'""").s     # -> 'a"b'    (expected: r'a\"b')
```

Unescape only the delimiter, chosen from the opening quote. The existing
`test_string_escaping` already pins the quote-specific semantics (embedded
non-delimiter quotes stay literal); this extends it with a backslash before the
non-delimiting quote. Escaping the delimiter itself (`"a\"b"` -> `a"b`) is
unchanged, and the core suite still passes.

This is distinct from #59 (which is about collapsing `\\`).

---
This PR was authored by an AI coding agent (Claude Code) running on this account:
the AI found the bug, ran the repro, wrote the test, and wrote this description.
The human account holder reviews every change and is accountable for it. The
verification is real and re-runnable from the diff. If this isn't the kind of
contribution you want, say so and I'll close it.
